### PR TITLE
Feature/14 type proxying

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -113,6 +113,6 @@ SpacesInCStyleCastParentheses: false
 SpacesInContainerLiterals: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: c++17
+Standard: c++20
 TabWidth: 4
 UseTab: Never

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,7 +24,8 @@ Checks: '*,
         -misc-no-recursion,
         -misc-unused-using-decls,
         -misc-unused-alias-decls,
-        -bugprone-easily-swappable-parameters'
+        -bugprone-easily-swappable-parameters,
+        -cppcoreguidelines-virtual-class-destructor'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 FormatStyle: none

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,14 @@
 cmake_minimum_required(VERSION 3.18)
 
 # Set the project name to your project name
-project(lbc CXX)
+project(lbc C CXX)
 include(cmake/StandardProjectSettings.cmake)
 include(cmake/PreventInSourceBuilds.cmake)
 include(cmake/llvm.cmake)
 
 # Link this 'library' to set the c++ standard / compileSource-time options requested
 add_library(project_options INTERFACE)
-target_compile_features(project_options INTERFACE cxx_std_17)
+target_compile_features(project_options INTERFACE cxx_std_20)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
     option(ENABLE_BUILD_WITH_TIME_TRACE "Enable -ftime-trace to generate time tracing .json files on clang" OFF)

--- a/scripts/build-llvm.bat
+++ b/scripts/build-llvm.bat
@@ -1,8 +1,8 @@
 @echo off
 
-set VERSION=llvm-13.0.1
+set VERSION=llvm-14.0.0-rc1
 
-set SRC=%cd%\%VERSION%.src
+set SRC=%cd%\%VERSION%.src\llvm
 set BUILD=%cd%\%VERSION%.build
 set INSTALL=%cd%\%VERSION%.dist
 
@@ -11,11 +11,13 @@ if not exist "%BUILD%" mkdir %BUILD%
 cmake -G "Ninja" -S "%SRC%" -B "%BUILD%" ^
     -DCMAKE_INSTALL_PREFIX="%INSTALL%" ^
     -DCMAKE_BUILD_TYPE=Release ^
-    -DCMAKE_CXX_STANDARD=17 ^
+    -DCMAKE_CXX_STANDARD=20 ^
     -DLLVM_ENABLE_ASSERTIONS=ON ^
     -DLLVM_TARGETS_TO_BUILD=X86 ^
     -DLLVM_OPTIMIZED_TABLEGEN=ON ^
-    -DLLVM_INSTALL_UTILS=ON
+    -DLLVM_INSTALL_UTILS=ON ^
+    -DLLVM_INCLUDE_BENCHMARKS=OFF ^
+    -DLLVM_INCLUDE_TESTS=OFF
 
 ninja -C "%BUILD%" install
 

--- a/scripts/build-llvm.sh
+++ b/scripts/build-llvm.sh
@@ -1,17 +1,19 @@
-VERSION="llvm-13.0.1"
+VERSION="llvm-14.0.0-rc1"
 
 mkdir $VERSION.build
 cd $VERSION.build/
 
 cmake -G "Unix Makefiles"           \
   -DCMAKE_INSTALL_PREFIX=/usr/local \
-  -DCMAKE_CXX_STANDARD=17           \
+  -DCMAKE_CXX_STANDARD=20           \
   -DCMAKE_BUILD_TYPE=Release        \
   -DLLVM_ENABLE_ASSERTIONS=ON       \
   -DLLVM_TARGETS_TO_BUILD=X86       \
   -DLLVM_OPTIMIZED_TABLEGEN=ON      \
   -DLLVM_INSTALL_UTILS=ON           \
-  ../$VERSION.src
+  -DLLVM_INCLUDE_BENCHMARKS=OFF     \
+  -DLLVM_INCLUDE_TESTS=OFF          \
+  ../$VERSION.src/llvm
 
 make -j12
 sudo make install

--- a/src/Ast/Ast.cpp
+++ b/src/Ast/Ast.cpp
@@ -45,11 +45,15 @@ bool AstAttributeList::exists(llvm::StringRef name) const noexcept {
 }
 
 const TypeRoot* AstTypeExpr::getType() const noexcept {
-    if (typeProxy == nullptr) { return nullptr; }
+    if (typeProxy == nullptr) {
+        return nullptr;
+    }
     return typeProxy->getType();
 }
 
 const TypeRoot* AstExpr::getType() const noexcept {
-    if (typeProxy == nullptr) { return nullptr; }
+    if (typeProxy == nullptr) {
+        return nullptr;
+    }
     return typeProxy->getType();
 }

--- a/src/Ast/Ast.cpp
+++ b/src/Ast/Ast.cpp
@@ -43,3 +43,13 @@ bool AstAttributeList::exists(llvm::StringRef name) const noexcept {
     });
     return iter != attribs.end();
 }
+
+const TypeRoot* AstTypeExpr::getType() const noexcept {
+    if (typeProxy == nullptr) { return nullptr; }
+    return typeProxy->getType();
+}
+
+const TypeRoot* AstExpr::getType() const noexcept {
+    if (typeProxy == nullptr) { return nullptr; }
+    return typeProxy->getType();
+}

--- a/src/Ast/Ast.hpp
+++ b/src/Ast/Ast.hpp
@@ -476,7 +476,6 @@ struct AstTypeExpr final : AstRoot {
 
     std::variant<AstIdentExpr*, AstFuncDecl*, TokenKind> expr;
     const int dereference;
-    // const TypeRoot* type = nullptr;
     TypeProxy* typeProxy = nullptr;
 };
 
@@ -489,8 +488,7 @@ struct AstExpr : AstRoot {
     static constexpr bool classof(const AstRoot* ast) noexcept {
         return AST_EXPR_RANGE(IS_AST_CLASSOF)
     }
-
-    // const TypeRoot* type = nullptr;
+    
     TypeProxy* typeProxy = nullptr;
     ValueFlags flags{};
 };

--- a/src/Ast/Ast.hpp
+++ b/src/Ast/Ast.hpp
@@ -488,7 +488,7 @@ struct AstExpr : AstRoot {
     static constexpr bool classof(const AstRoot* ast) noexcept {
         return AST_EXPR_RANGE(IS_AST_CLASSOF)
     }
-    
+
     TypeProxy* typeProxy = nullptr;
     ValueFlags flags{};
 };

--- a/src/Ast/Ast.hpp
+++ b/src/Ast/Ast.hpp
@@ -9,7 +9,7 @@
 #include "ValueFlags.hpp"
 
 namespace lbc {
-class TypeRoot;
+class TypeProxy;
 AST_FORWARD_DECLARE() // NOLINT(cppcoreguidelines-virtual-class-destructor)
 
 enum class AstKind {
@@ -41,7 +41,7 @@ struct AstRoot {
 
     // Allow placement new
     void* operator new(size_t /*size*/, void* ptr) {
-        assert(ptr);
+        assert(ptr); // NOLINT
         return ptr;
     }
 };
@@ -476,7 +476,8 @@ struct AstTypeExpr final : AstRoot {
 
     std::variant<AstIdentExpr*, AstFuncDecl*, TokenKind> expr;
     const int dereference;
-    const TypeRoot* type = nullptr;
+    // const TypeRoot* type = nullptr;
+    TypeProxy* typeProxy = nullptr;
 };
 
 //----------------------------------------
@@ -489,7 +490,8 @@ struct AstExpr : AstRoot {
         return AST_EXPR_RANGE(IS_AST_CLASSOF)
     }
 
-    const TypeRoot* type = nullptr;
+    // const TypeRoot* type = nullptr;
+    TypeProxy* typeProxy = nullptr;
     ValueFlags flags{};
 };
 

--- a/src/Ast/Ast.hpp
+++ b/src/Ast/Ast.hpp
@@ -10,7 +10,7 @@
 
 namespace lbc {
 class TypeProxy;
-AST_FORWARD_DECLARE() // NOLINT(cppcoreguidelines-virtual-class-destructor)
+AST_FORWARD_DECLARE()
 
 enum class AstKind {
 #define KIND_ENUM(id, ...) id,

--- a/src/Ast/Ast.hpp
+++ b/src/Ast/Ast.hpp
@@ -10,6 +10,7 @@
 
 namespace lbc {
 class TypeProxy;
+class TypeRoot;
 AST_FORWARD_DECLARE()
 
 enum class AstKind {
@@ -474,6 +475,8 @@ struct AstTypeExpr final : AstRoot {
         return ast->kind == AstKind::TypeExpr;
     }
 
+    [[nodiscard]] const TypeRoot* getType() const noexcept;
+
     std::variant<AstIdentExpr*, AstFuncDecl*, TokenKind> expr;
     const int dereference;
     TypeProxy* typeProxy = nullptr;
@@ -488,6 +491,8 @@ struct AstExpr : AstRoot {
     static constexpr bool classof(const AstRoot* ast) noexcept {
         return AST_EXPR_RANGE(IS_AST_CLASSOF)
     }
+
+    [[nodiscard]] const TypeRoot* getType() const noexcept;
 
     TypeProxy* typeProxy = nullptr;
     ValueFlags flags{};

--- a/src/Ast/AstPrinter.cpp
+++ b/src/Ast/AstPrinter.cpp
@@ -6,6 +6,7 @@
 #include "Driver/Context.hpp"
 #include "Lexer/Token.hpp"
 #include "Type/Type.hpp"
+#include "Type/TypeProxy.hpp"
 using namespace lbc;
 
 AstPrinter::AstPrinter(Context& context, llvm::raw_ostream& os) noexcept
@@ -309,7 +310,7 @@ void AstPrinter::visit(AstTypeExpr& ast) {
     m_json.object([&] {
         writeHeader(ast);
         std::string name;
-        if (const auto* type = ast.type) {
+        if (const auto* type = ast.typeProxy->getType()) {
             name = type->asString();
         } else {
             static constexpr auto visitor = Visitor{
@@ -361,7 +362,8 @@ void AstPrinter::visit(AstLiteralExpr& ast) {
             return { TokenKind::StringLiteral, value.str() };
         },
         [&](uint64_t value) -> Ret {
-            if (ast.type == nullptr || ast.type->isSignedIntegral()) {
+            const auto* type = ast.typeProxy->getType();
+            if (type == nullptr || type->isSignedIntegral()) {
                 auto sval = static_cast<int64_t>(value);
                 return { TokenKind::IntegerLiteral, std::to_string(sval) };
             }
@@ -380,8 +382,8 @@ void AstPrinter::visit(AstLiteralExpr& ast) {
         auto [kind, value] = std::visit(visitor, ast.value);
         m_json.attribute("kind", Token::description(kind));
         m_json.attribute("value", value);
-        if (ast.type != nullptr) {
-            m_json.attribute("type", ast.type->asString());
+        if (ast.typeProxy->getType() != nullptr) {
+            m_json.attribute("type", ast.typeProxy->getType()->asString());
         }
     });
 }

--- a/src/Ast/AstPrinter.cpp
+++ b/src/Ast/AstPrinter.cpp
@@ -310,7 +310,7 @@ void AstPrinter::visit(AstTypeExpr& ast) {
     m_json.object([&] {
         writeHeader(ast);
         std::string name;
-        if (const auto* type = ast.typeProxy->getType()) {
+        if (const auto* type = ast.getType()) {
             name = type->asString();
         } else {
             static constexpr auto visitor = Visitor{
@@ -362,7 +362,7 @@ void AstPrinter::visit(AstLiteralExpr& ast) {
             return { TokenKind::StringLiteral, value.str() };
         },
         [&](uint64_t value) -> Ret {
-            const auto* type = ast.typeProxy->getType();
+            const auto* type = ast.getType();
             if (type == nullptr || type->isSignedIntegral()) {
                 auto sval = static_cast<int64_t>(value);
                 return { TokenKind::IntegerLiteral, std::to_string(sval) };
@@ -382,8 +382,8 @@ void AstPrinter::visit(AstLiteralExpr& ast) {
         auto [kind, value] = std::visit(visitor, ast.value);
         m_json.attribute("kind", Token::description(kind));
         m_json.attribute("value", value);
-        if (ast.typeProxy->getType() != nullptr) {
-            m_json.attribute("type", ast.typeProxy->getType()->asString());
+        if (ast.getType() != nullptr) {
+            m_json.attribute("type", ast.getType()->asString());
         }
     });
 }

--- a/src/Ast/CodePrinter.cpp
+++ b/src/Ast/CodePrinter.cpp
@@ -5,6 +5,7 @@
 #include "Ast.hpp"
 #include "Lexer/Token.hpp"
 #include "Type/Type.hpp"
+#include "Type/TypeProxy.hpp"
 using namespace lbc;
 
 void CodePrinter::visit(AstModule& ast) {
@@ -78,7 +79,7 @@ void CodePrinter::visit(AstAttribute& ast) {
 }
 
 void CodePrinter::visit(AstTypeExpr& ast) {
-    if (const auto* type = ast.type) {
+    if (const auto* type = ast.typeProxy->getType()) {
         m_os << type->asString();
         return;
     }
@@ -403,7 +404,8 @@ void CodePrinter::visit(AstLiteralExpr& ast) {
             return '"' + result + '"';
         },
         [&](uint64_t value) -> std::string {
-            if (ast.type == nullptr || ast.type->isSignedIntegral()) {
+            const auto* type = ast.typeProxy->getType();
+            if (type == nullptr || type->isSignedIntegral()) {
                 auto sval = static_cast<int64_t>(value);
                 return std::to_string(sval);
             }
@@ -472,8 +474,9 @@ void CodePrinter::visit(AstCastExpr& ast) {
     visit(*ast.expr);
     m_os << " AS ";
     if (ast.implicit) {
-        if (ast.type != nullptr) {
-            m_os << ast.type->asString();
+        const auto* type = ast.typeProxy->getType();
+        if (type != nullptr) {
+            m_os << type->asString();
         } else {
             m_os << "ANY";
         }

--- a/src/Ast/CodePrinter.cpp
+++ b/src/Ast/CodePrinter.cpp
@@ -79,7 +79,7 @@ void CodePrinter::visit(AstAttribute& ast) {
 }
 
 void CodePrinter::visit(AstTypeExpr& ast) {
-    if (const auto* type = ast.typeProxy->getType()) {
+    if (const auto* type = ast.getType()) {
         m_os << type->asString();
         return;
     }
@@ -404,7 +404,7 @@ void CodePrinter::visit(AstLiteralExpr& ast) {
             return '"' + result + '"';
         },
         [&](uint64_t value) -> std::string {
-            const auto* type = ast.typeProxy->getType();
+            const auto* type = ast.getType();
             if (type == nullptr || type->isSignedIntegral()) {
                 auto sval = static_cast<int64_t>(value);
                 return std::to_string(sval);
@@ -474,7 +474,7 @@ void CodePrinter::visit(AstCastExpr& ast) {
     visit(*ast.expr);
     m_os << " AS ";
     if (ast.implicit) {
-        const auto* type = ast.typeProxy->getType();
+        const auto* type = ast.getType();
         if (type != nullptr) {
             m_os << type->asString();
         } else {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,7 +85,7 @@ add_library(
     Utils/Utils.hpp
     Utils/ValueRestorer.hpp
     Utils/Version.hpp
-)
+    Type/TypeProxy.hpp)
 
 target_precompile_headers(project_options INTERFACE pch.hpp)
 target_include_directories(lbc_lib PUBLIC ${lbc_SOURCE_DIR}/src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,7 +85,7 @@ add_library(
     Utils/Utils.hpp
     Utils/ValueRestorer.hpp
     Utils/Version.hpp
-    Type/TypeProxy.hpp)
+    Type/TypeProxy.hpp Symbol/Symbol.cpp)
 
 target_precompile_headers(project_options INTERFACE pch.hpp)
 target_include_directories(lbc_lib PUBLIC ${lbc_SOURCE_DIR}/src)

--- a/src/Driver/Driver.cpp
+++ b/src/Driver/Driver.cpp
@@ -12,6 +12,7 @@
 #include "TempFileCache.hpp"
 #include "Toolchain/ToolTask.hpp"
 #include <llvm/IR/IRPrintingPasses.h>
+#include <llvm/Pass.h>
 #include <llvm/Support/FileSystem.h>
 
 using namespace lbc;

--- a/src/Gen/Builders/BinaryExprBuilder.cpp
+++ b/src/Gen/Builders/BinaryExprBuilder.cpp
@@ -5,6 +5,7 @@
 #include "Driver/Context.hpp"
 #include "Gen/Helpers.hpp"
 #include "Type/Type.hpp"
+#include "Type/TypeProxy.hpp"
 using namespace lbc;
 using namespace Gen;
 
@@ -25,17 +26,17 @@ ValueHandler BinaryExprBuilder::comparison() {
     auto* lhsValue = m_gen.visit(*m_ast.lhs).load();
     auto* rhsValue = m_gen.visit(*m_ast.rhs).load();
 
-    const auto* ty = m_ast.lhs->type;
+    const auto* ty = m_ast.lhs->typeProxy->getType();
     auto pred = Gen::getCmpPred(ty, m_ast.tokenKind);
-    return { &m_gen, m_ast.type, m_builder.CreateCmp(pred, lhsValue, rhsValue) };
+    return { &m_gen, m_ast.typeProxy->getType(), m_builder.CreateCmp(pred, lhsValue, rhsValue) };
 }
 
 ValueHandler BinaryExprBuilder::arithmetic() {
     auto* lhsValue = m_gen.visit(*m_ast.lhs).load();
     auto* rhsValue = m_gen.visit(*m_ast.rhs).load();
 
-    auto op = getBinOpPred(m_ast.lhs->type, m_ast.tokenKind);
-    return { &m_gen, m_ast.type, m_builder.CreateBinOp(op, lhsValue, rhsValue) };
+    auto op = getBinOpPred(m_ast.lhs->typeProxy->getType(), m_ast.tokenKind);
+    return { &m_gen, m_ast.typeProxy->getType(), m_builder.CreateBinOp(op, lhsValue, rhsValue) };
 }
 
 ValueHandler BinaryExprBuilder::logical() {
@@ -62,7 +63,7 @@ ValueHandler BinaryExprBuilder::logical() {
 
     // phi
     m_gen.switchBlock(endBlock);
-    auto* phi = m_builder.CreatePHI(m_ast.type->getLlvmType(m_gen.getContext()), 2);
+    auto* phi = m_builder.CreatePHI(m_ast.typeProxy->getType()->getLlvmType(m_gen.getContext()), 2);
 
     if (isAnd) {
         phi->addIncoming(m_gen.getFalse(), lhsBlock);
@@ -70,5 +71,5 @@ ValueHandler BinaryExprBuilder::logical() {
         phi->addIncoming(m_gen.getTrue(), lhsBlock);
     }
     phi->addIncoming(rhsValue, rhsBlock);
-    return { &m_gen, m_ast.type, phi };
+    return { &m_gen, m_ast.typeProxy->getType(), phi };
 }

--- a/src/Gen/Builders/BinaryExprBuilder.cpp
+++ b/src/Gen/Builders/BinaryExprBuilder.cpp
@@ -26,17 +26,17 @@ ValueHandler BinaryExprBuilder::comparison() {
     auto* lhsValue = m_gen.visit(*m_ast.lhs).load();
     auto* rhsValue = m_gen.visit(*m_ast.rhs).load();
 
-    const auto* ty = m_ast.lhs->typeProxy->getType();
+    const auto* ty = m_ast.lhs->getType();
     auto pred = Gen::getCmpPred(ty, m_ast.tokenKind);
-    return { &m_gen, m_ast.typeProxy->getType(), m_builder.CreateCmp(pred, lhsValue, rhsValue) };
+    return { &m_gen, m_ast.getType(), m_builder.CreateCmp(pred, lhsValue, rhsValue) };
 }
 
 ValueHandler BinaryExprBuilder::arithmetic() {
     auto* lhsValue = m_gen.visit(*m_ast.lhs).load();
     auto* rhsValue = m_gen.visit(*m_ast.rhs).load();
 
-    auto op = getBinOpPred(m_ast.lhs->typeProxy->getType(), m_ast.tokenKind);
-    return { &m_gen, m_ast.typeProxy->getType(), m_builder.CreateBinOp(op, lhsValue, rhsValue) };
+    auto op = getBinOpPred(m_ast.lhs->getType(), m_ast.tokenKind);
+    return { &m_gen, m_ast.getType(), m_builder.CreateBinOp(op, lhsValue, rhsValue) };
 }
 
 ValueHandler BinaryExprBuilder::logical() {
@@ -63,7 +63,7 @@ ValueHandler BinaryExprBuilder::logical() {
 
     // phi
     m_gen.switchBlock(endBlock);
-    auto* phi = m_builder.CreatePHI(m_ast.typeProxy->getType()->getLlvmType(m_gen.getContext()), 2);
+    auto* phi = m_builder.CreatePHI(m_ast.getType()->getLlvmType(m_gen.getContext()), 2);
 
     if (isAnd) {
         phi->addIncoming(m_gen.getFalse(), lhsBlock);
@@ -71,5 +71,5 @@ ValueHandler BinaryExprBuilder::logical() {
         phi->addIncoming(m_gen.getTrue(), lhsBlock);
     }
     phi->addIncoming(rhsValue, rhsBlock);
-    return { &m_gen, m_ast.typeProxy->getType(), phi };
+    return { &m_gen, m_ast.getType(), phi };
 }

--- a/src/Gen/Builders/Builder.hpp
+++ b/src/Gen/Builders/Builder.hpp
@@ -7,7 +7,8 @@
 
 namespace lbc::Gen {
 
-template<typename T, std::enable_if_t<std::is_base_of_v<AstRoot, T>, int> = 0>
+template<typename T>
+requires std::is_base_of_v<AstRoot, T>
 class Builder {
 public:
     Builder(CodeGen& gen, T& ast) noexcept

--- a/src/Gen/Builders/ForStmtBuilder.cpp
+++ b/src/Gen/Builders/ForStmtBuilder.cpp
@@ -33,7 +33,7 @@ void ForStmtBuilder::declareVars() {
     }
     m_gen.visit(*m_ast.iterator);
 
-    m_type = m_ast.iterator->symbol->getTypeProxy()->getType();
+    m_type = m_ast.iterator->symbol->getType();
     m_llvmType = m_type->getLlvmType(m_gen.getContext());
 
     m_iterator = ValueHandler{ &m_gen, m_ast.iterator->symbol };
@@ -76,7 +76,7 @@ void ForStmtBuilder::configureStep() {
 
     // Literal value
     if (auto* literal = llvm::dyn_cast<AstLiteralExpr>(m_ast.step)) {
-        const auto* stepTy = literal->typeProxy->getType();
+        const auto* stepTy = literal->getType();
         llvm::Constant* stepVal = nullptr;
         if (const auto* integral = llvm::dyn_cast<TypeIntegral>(stepTy)) {
             auto stepLit = std::get<uint64_t>(literal->value);
@@ -105,7 +105,7 @@ void ForStmtBuilder::configureStep() {
     auto* stepValue = m_step.load();
 
     auto* isStepNeg = m_builder.CreateCmp(
-        getCmpPred(m_ast.step->typeProxy->getType(), TokenKind::LessThan),
+        getCmpPred(m_ast.step->getType(), TokenKind::LessThan),
         stepValue,
         llvm::Constant::getNullValue(m_llvmType),
         "for.isStepNeg");

--- a/src/Gen/Builders/ForStmtBuilder.cpp
+++ b/src/Gen/Builders/ForStmtBuilder.cpp
@@ -9,6 +9,7 @@
 #include "Gen/ValueHandler.hpp"
 #include "Symbol/Symbol.hpp"
 #include "Type/Type.hpp"
+#include "Type/TypeProxy.hpp"
 using namespace lbc;
 using namespace Gen;
 
@@ -32,7 +33,7 @@ void ForStmtBuilder::declareVars() {
     }
     m_gen.visit(*m_ast.iterator);
 
-    m_type = m_ast.iterator->symbol->type();
+    m_type = m_ast.iterator->symbol->getTypeProxy()->getType();
     m_llvmType = m_type->getLlvmType(m_gen.getContext());
 
     m_iterator = ValueHandler{ &m_gen, m_ast.iterator->symbol };
@@ -75,7 +76,7 @@ void ForStmtBuilder::configureStep() {
 
     // Literal value
     if (auto* literal = llvm::dyn_cast<AstLiteralExpr>(m_ast.step)) {
-        const auto* stepTy = literal->type;
+        const auto* stepTy = literal->typeProxy->getType();
         llvm::Constant* stepVal = nullptr;
         if (const auto* integral = llvm::dyn_cast<TypeIntegral>(stepTy)) {
             auto stepLit = std::get<uint64_t>(literal->value);
@@ -104,7 +105,7 @@ void ForStmtBuilder::configureStep() {
     auto* stepValue = m_step.load();
 
     auto* isStepNeg = m_builder.CreateCmp(
-        getCmpPred(m_ast.step->type, TokenKind::LessThan),
+        getCmpPred(m_ast.step->typeProxy->getType(), TokenKind::LessThan),
         stepValue,
         llvm::Constant::getNullValue(m_llvmType),
         "for.isStepNeg");

--- a/src/Gen/CodeGen.cpp
+++ b/src/Gen/CodeGen.cpp
@@ -182,7 +182,7 @@ void CodeGen::visit(AstVarDecl& ast) {
 void CodeGen::declareGlobalVar(AstVarDecl& ast) {
     auto* sym = ast.symbol;
     llvm::Constant* constant = nullptr;
-    llvm::Type* exprType = sym->getTypeProxy()->getType()->getLlvmType(m_context);
+    llvm::Type* exprType = sym->getType()->getLlvmType(m_context);
     bool generateStoreInCtror = false;
 
     // has an init expr?
@@ -218,7 +218,7 @@ void CodeGen::declareGlobalVar(AstVarDecl& ast) {
 }
 
 void CodeGen::declareLocalVar(AstVarDecl& ast) {
-    llvm::Type* exprType = ast.symbol->getTypeProxy()->getType()->getLlvmType(m_context);
+    llvm::Type* exprType = ast.symbol->getType()->getLlvmType(m_context);
     auto* lvalue = m_builder.CreateAlloca(exprType, nullptr, ast.symbol->identifier());
 
     // has an init expr?
@@ -260,7 +260,7 @@ void CodeGen::declareFuncs(AstStmtList& ast) {
 
 void CodeGen::declareFunc(AstFuncDecl& ast) {
     auto* sym = ast.symbol;
-    auto* fnTy = llvm::cast<llvm::FunctionType>(ast.symbol->getTypeProxy()->getType()->getLlvmType(m_context));
+    auto* fnTy = llvm::cast<llvm::FunctionType>(ast.symbol->getType()->getLlvmType(m_context));
     auto* fn = llvm::Function::Create(
         fnTy,
         sym->getLlvmLinkage(),
@@ -302,7 +302,7 @@ void CodeGen::visit(AstFuncStmt& ast) {
             auto* sym = param->symbol;
             auto* value = sym->getLlvmValue();
             sym->setLlvmValue(m_builder.CreateAlloca(
-                sym->getTypeProxy()->getType()->getLlvmType(m_context),
+                sym->getType()->getLlvmType(m_context),
                 nullptr,
                 sym->identifier() + ".addr"));
             m_builder.CreateStore(value, sym->getLlvmValue());
@@ -456,34 +456,34 @@ ValueHandler CodeGen::visit(AstCallExpr& ast) {
 
     auto* call = m_builder.CreateCall(fnType, callable, values, "");
     call->setTailCall(false);
-    return { this, ast.typeProxy->getType(), call };
+    return { this, ast.getType(), call };
 }
 
 ValueHandler CodeGen::visit(AstLiteralExpr& ast) {
     const auto visitor = Visitor{
         [&](std::monostate /*value*/) -> llvm::Value* {
             return llvm::ConstantPointerNull::get(
-                llvm::cast<llvm::PointerType>(ast.typeProxy->getType()->getLlvmType(m_context)));
+                llvm::cast<llvm::PointerType>(ast.getType()->getLlvmType(m_context)));
         },
         [&](llvm::StringRef str) -> llvm::Value* {
             return getStringConstant(str);
         },
         [&](uint64_t value) -> llvm::Value* {
             return llvm::ConstantInt::get(
-                ast.typeProxy->getType()->getLlvmType(m_context),
+                ast.getType()->getLlvmType(m_context),
                 value,
-                static_cast<const TypeIntegral*>(ast.typeProxy->getType())->isSigned());
+                static_cast<const TypeIntegral*>(ast.getType())->isSigned());
         },
         [&](double value) -> llvm::Value* {
             return llvm::ConstantFP::get(
-                ast.typeProxy->getType()->getLlvmType(m_context),
+                ast.getType()->getLlvmType(m_context),
                 value);
         },
         [&](bool value) -> llvm::Value* {
             return value ? m_constantTrue : m_constantFalse;
         }
     };
-    return { this, ast.typeProxy->getType(), std::visit(visitor, ast.value) };
+    return { this, ast.getType(), std::visit(visitor, ast.value) };
 }
 
 llvm::Constant* CodeGen::getStringConstant(llvm::StringRef str) {
@@ -500,18 +500,18 @@ ValueHandler CodeGen::visit(AstUnaryExpr& ast) {
         auto* value = visit(*ast.expr).load();
 
         if (value->getType()->isIntegerTy()) {
-            return { this, ast.typeProxy->getType(), m_builder.CreateNeg(value) };
+            return { this, ast.getType(), m_builder.CreateNeg(value) };
         }
 
         if (value->getType()->isFloatingPointTy()) {
-            return { this, ast.typeProxy->getType(), m_builder.CreateFNeg(value) };
+            return { this, ast.getType(), m_builder.CreateFNeg(value) };
         }
 
         llvm_unreachable("Unexpected unary operator");
     }
     case TokenKind::LogicalNot: {
         auto value = visit(*ast.expr);
-        return { this, ast.typeProxy->getType(), m_builder.CreateNot(value.load(), "lnot") };
+        return { this, ast.getType(), m_builder.CreateNot(value.load(), "lnot") };
     }
     default:
         llvm_unreachable("Unexpected unary operator");
@@ -533,17 +533,17 @@ ValueHandler CodeGen::visit(AstBinaryExpr& ast) {
 ValueHandler CodeGen::visit(AstCastExpr& ast) {
     auto* value = visit(*ast.expr).load();
 
-    bool srcIsSigned = ast.expr->typeProxy->getType()->isSignedIntegral();
-    bool dstIsSigned = ast.typeProxy->getType()->isSignedIntegral();
+    bool srcIsSigned = ast.expr->getType()->isSignedIntegral();
+    bool dstIsSigned = ast.getType()->isSignedIntegral();
 
     auto opcode = llvm::CastInst::getCastOpcode(
         value,
         srcIsSigned,
-        ast.typeProxy->getType()->getLlvmType(m_context),
+        ast.getType()->getLlvmType(m_context),
         dstIsSigned);
-    auto* casted = m_builder.CreateCast(opcode, value, ast.typeProxy->getType()->getLlvmType(m_context));
+    auto* casted = m_builder.CreateCast(opcode, value, ast.getType()->getLlvmType(m_context));
 
-    return { this, ast.typeProxy->getType(), casted };
+    return { this, ast.getType(), casted };
 }
 
 ValueHandler CodeGen::visit(AstIfExpr& ast) {
@@ -552,7 +552,7 @@ ValueHandler CodeGen::visit(AstIfExpr& ast) {
     auto falseValue = visit(*ast.falseExpr);
 
     auto* value = m_builder.CreateSelect(condValue.load(), trueValue.load(), falseValue.load());
-    return { this, ast.typeProxy->getType(), value };
+    return { this, ast.getType(), value };
 }
 
 std::unique_ptr<llvm::Module> CodeGen::getModule() {

--- a/src/Gen/CodeGen.cpp
+++ b/src/Gen/CodeGen.cpp
@@ -9,6 +9,7 @@
 #include "Driver/Context.hpp"
 #include "Helpers.hpp"
 #include "Type/Type.hpp"
+#include "Type/TypeProxy.hpp"
 #include "ValueHandler.hpp"
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/IRPrintingPasses.h>
@@ -181,7 +182,7 @@ void CodeGen::visit(AstVarDecl& ast) {
 void CodeGen::declareGlobalVar(AstVarDecl& ast) {
     auto* sym = ast.symbol;
     llvm::Constant* constant = nullptr;
-    llvm::Type* exprType = sym->type()->getLlvmType(m_context);
+    llvm::Type* exprType = sym->getTypeProxy()->getType()->getLlvmType(m_context);
     bool generateStoreInCtror = false;
 
     // has an init expr?
@@ -217,7 +218,7 @@ void CodeGen::declareGlobalVar(AstVarDecl& ast) {
 }
 
 void CodeGen::declareLocalVar(AstVarDecl& ast) {
-    llvm::Type* exprType = ast.symbol->type()->getLlvmType(m_context);
+    llvm::Type* exprType = ast.symbol->getTypeProxy()->getType()->getLlvmType(m_context);
     auto* lvalue = m_builder.CreateAlloca(exprType, nullptr, ast.symbol->identifier());
 
     // has an init expr?
@@ -259,7 +260,7 @@ void CodeGen::declareFuncs(AstStmtList& ast) {
 
 void CodeGen::declareFunc(AstFuncDecl& ast) {
     auto* sym = ast.symbol;
-    auto* fnTy = llvm::cast<llvm::FunctionType>(ast.symbol->type()->getLlvmType(m_context));
+    auto* fnTy = llvm::cast<llvm::FunctionType>(ast.symbol->getTypeProxy()->getType()->getLlvmType(m_context));
     auto* fn = llvm::Function::Create(
         fnTy,
         sym->getLlvmLinkage(),
@@ -301,7 +302,7 @@ void CodeGen::visit(AstFuncStmt& ast) {
             auto* sym = param->symbol;
             auto* value = sym->getLlvmValue();
             sym->setLlvmValue(m_builder.CreateAlloca(
-                sym->type()->getLlvmType(m_context),
+                sym->getTypeProxy()->getType()->getLlvmType(m_context),
                 nullptr,
                 sym->identifier() + ".addr"));
             m_builder.CreateStore(value, sym->getLlvmValue());
@@ -455,34 +456,34 @@ ValueHandler CodeGen::visit(AstCallExpr& ast) {
 
     auto* call = m_builder.CreateCall(fnType, callable, values, "");
     call->setTailCall(false);
-    return { this, ast.type, call };
+    return { this, ast.typeProxy->getType(), call };
 }
 
 ValueHandler CodeGen::visit(AstLiteralExpr& ast) {
     const auto visitor = Visitor{
         [&](std::monostate /*value*/) -> llvm::Value* {
             return llvm::ConstantPointerNull::get(
-                llvm::cast<llvm::PointerType>(ast.type->getLlvmType(m_context)));
+                llvm::cast<llvm::PointerType>(ast.typeProxy->getType()->getLlvmType(m_context)));
         },
         [&](llvm::StringRef str) -> llvm::Value* {
             return getStringConstant(str);
         },
         [&](uint64_t value) -> llvm::Value* {
             return llvm::ConstantInt::get(
-                ast.type->getLlvmType(m_context),
+                ast.typeProxy->getType()->getLlvmType(m_context),
                 value,
-                static_cast<const TypeIntegral*>(ast.type)->isSigned());
+                static_cast<const TypeIntegral*>(ast.typeProxy->getType())->isSigned());
         },
         [&](double value) -> llvm::Value* {
             return llvm::ConstantFP::get(
-                ast.type->getLlvmType(m_context),
+                ast.typeProxy->getType()->getLlvmType(m_context),
                 value);
         },
         [&](bool value) -> llvm::Value* {
             return value ? m_constantTrue : m_constantFalse;
         }
     };
-    return { this, ast.type, std::visit(visitor, ast.value) };
+    return { this, ast.typeProxy->getType(), std::visit(visitor, ast.value) };
 }
 
 llvm::Constant* CodeGen::getStringConstant(llvm::StringRef str) {
@@ -499,18 +500,18 @@ ValueHandler CodeGen::visit(AstUnaryExpr& ast) {
         auto* value = visit(*ast.expr).load();
 
         if (value->getType()->isIntegerTy()) {
-            return { this, ast.type, m_builder.CreateNeg(value) };
+            return { this, ast.typeProxy->getType(), m_builder.CreateNeg(value) };
         }
 
         if (value->getType()->isFloatingPointTy()) {
-            return { this, ast.type, m_builder.CreateFNeg(value) };
+            return { this, ast.typeProxy->getType(), m_builder.CreateFNeg(value) };
         }
 
         llvm_unreachable("Unexpected unary operator");
     }
     case TokenKind::LogicalNot: {
         auto value = visit(*ast.expr);
-        return { this, ast.type, m_builder.CreateNot(value.load(), "lnot") };
+        return { this, ast.typeProxy->getType(), m_builder.CreateNot(value.load(), "lnot") };
     }
     default:
         llvm_unreachable("Unexpected unary operator");
@@ -532,17 +533,17 @@ ValueHandler CodeGen::visit(AstBinaryExpr& ast) {
 ValueHandler CodeGen::visit(AstCastExpr& ast) {
     auto* value = visit(*ast.expr).load();
 
-    bool srcIsSigned = ast.expr->type->isSignedIntegral();
-    bool dstIsSigned = ast.type->isSignedIntegral();
+    bool srcIsSigned = ast.expr->typeProxy->getType()->isSignedIntegral();
+    bool dstIsSigned = ast.typeProxy->getType()->isSignedIntegral();
 
     auto opcode = llvm::CastInst::getCastOpcode(
         value,
         srcIsSigned,
-        ast.type->getLlvmType(m_context),
+        ast.typeProxy->getType()->getLlvmType(m_context),
         dstIsSigned);
-    auto* casted = m_builder.CreateCast(opcode, value, ast.type->getLlvmType(m_context));
+    auto* casted = m_builder.CreateCast(opcode, value, ast.typeProxy->getType()->getLlvmType(m_context));
 
-    return { this, ast.type, casted };
+    return { this, ast.typeProxy->getType(), casted };
 }
 
 ValueHandler CodeGen::visit(AstIfExpr& ast) {
@@ -551,7 +552,7 @@ ValueHandler CodeGen::visit(AstIfExpr& ast) {
     auto falseValue = visit(*ast.falseExpr);
 
     auto* value = m_builder.CreateSelect(condValue.load(), trueValue.load(), falseValue.load());
-    return { this, ast.type, value };
+    return { this, ast.typeProxy->getType(), value };
 }
 
 std::unique_ptr<llvm::Module> CodeGen::getModule() {

--- a/src/Gen/CodeGen.cpp
+++ b/src/Gen/CodeGen.cpp
@@ -443,7 +443,7 @@ ValueHandler CodeGen::visit(AstCallExpr& ast) {
     if (auto* func = llvm::dyn_cast<llvm::Function>(callable)) {
         fnType = func->getFunctionType();
     } else if (const auto* ptr = llvm::dyn_cast<llvm::PointerType>(callable->getType())) {
-        fnType = llvm::cast<llvm::FunctionType>(ptr->getElementType());
+        fnType = llvm::cast<llvm::FunctionType>(ptr->getPointerElementType());
     }
 
     const auto& args = ast.args->exprs;

--- a/src/Gen/ValueHandler.cpp
+++ b/src/Gen/ValueHandler.cpp
@@ -39,7 +39,7 @@ ValueHandler ValueHandler::createTempOrConstant(CodeGen& gen, AstExpr& expr, llv
 }
 
 ValueHandler ValueHandler::createOpaqueValue(CodeGen& gen, const TypeRoot* type, llvm::Value* value, llvm::StringRef name) noexcept {
-    auto* typeProxy = gen.getContext().create<TypeProxy>(type);
+    auto* typeProxy = type->getProxy();
     auto* symbol = gen.getContext().create<Symbol>(name, typeProxy);
     symbol->setLlvmValue(value);
     return { &gen, symbol };

--- a/src/Gen/ValueHandler.cpp
+++ b/src/Gen/ValueHandler.cpp
@@ -15,27 +15,27 @@ using namespace Gen;
 ValueHandler ValueHandler::createTemp(CodeGen& gen, AstExpr& expr, llvm::StringRef name) noexcept {
     auto* value = gen.visit(expr).load();
     auto* var = gen.getBuilder().CreateAlloca(
-        expr.typeProxy->getType()->getLlvmType(gen.getContext()),
+        expr.getType()->getLlvmType(gen.getContext()),
         nullptr,
         name);
     gen.getBuilder().CreateStore(value, var);
 
-    return createOpaqueValue(gen, expr.typeProxy->getType(), var, name);
+    return createOpaqueValue(gen, expr.getType(), var, name);
 }
 
 ValueHandler ValueHandler::createTempOrConstant(CodeGen& gen, AstExpr& expr, llvm::StringRef name) noexcept {
     auto* value = gen.visit(expr).load();
     if (llvm::isa<llvm::Constant>(value)) {
-        return { &gen, expr.typeProxy->getType(), value };
+        return { &gen, expr.getType(), value };
     }
 
     auto* var = gen.getBuilder().CreateAlloca(
-        expr.typeProxy->getType()->getLlvmType(gen.getContext()),
+        expr.getType()->getLlvmType(gen.getContext()),
         nullptr,
         name);
     gen.getBuilder().CreateStore(value, var);
 
-    return createOpaqueValue(gen, expr.typeProxy->getType(), var, name);
+    return createOpaqueValue(gen, expr.getType(), var, name);
 }
 
 ValueHandler ValueHandler::createOpaqueValue(CodeGen& gen, const TypeRoot* type, llvm::Value* value, llvm::StringRef name) noexcept {
@@ -49,19 +49,19 @@ ValueHandler::ValueHandler(CodeGen* gen, const TypeRoot* type, llvm::Value* valu
 : PointerUnion{ value }, m_gen{ gen }, m_type{ type } {}
 
 ValueHandler::ValueHandler(CodeGen* gen, Symbol* symbol) noexcept
-: PointerUnion{ symbol }, m_gen{ gen }, m_type{ symbol->getTypeProxy()->getType() } {}
+: PointerUnion{ symbol }, m_gen{ gen }, m_type{ symbol->getType() } {}
 
 ValueHandler::ValueHandler(CodeGen* gen, AstIdentExpr& ast) noexcept
 : ValueHandler{ gen, ast.symbol } {}
 
 ValueHandler::ValueHandler(CodeGen* gen, AstMemberAccess& ast) noexcept
-: PointerUnion{ &ast }, m_gen{ gen }, m_type{ ast.typeProxy->getType() } {}
+: PointerUnion{ &ast }, m_gen{ gen }, m_type{ ast.getType() } {}
 
 ValueHandler::ValueHandler(CodeGen* gen, AstAddressOf& ast) noexcept
-: PointerUnion{ &ast }, m_gen{ gen }, m_type{ ast.typeProxy->getType() } {}
+: PointerUnion{ &ast }, m_gen{ gen }, m_type{ ast.getType() } {}
 
 ValueHandler::ValueHandler(CodeGen* gen, AstDereference& ast) noexcept
-: PointerUnion{ &ast }, m_gen{ gen }, m_type{ ast.typeProxy->getType() } {}
+: PointerUnion{ &ast }, m_gen{ gen }, m_type{ ast.getType() } {}
 
 llvm::Value* ValueHandler::getAddress() const noexcept {
     if (auto* value = dyn_cast<llvm::Value*>()) {
@@ -110,11 +110,11 @@ llvm::Type* ValueHandler::getLlvmType() const noexcept {
     }
 
     if (auto* symbol = dyn_cast<Symbol*>()) {
-        return symbol->getTypeProxy()->getType()->getLlvmType(m_gen->getContext());
+        return symbol->getType()->getLlvmType(m_gen->getContext());
     }
 
     if (auto* ast = dyn_cast<AstExpr*>()) {
-        return ast->typeProxy->getType()->getLlvmType(m_gen->getContext());
+        return ast->getType()->getLlvmType(m_gen->getContext());
     }
 
     llvm_unreachable("Unknown type in getLlvmType");
@@ -147,17 +147,17 @@ llvm::Value* ValueHandler::getAggregageAddress(AstMemberAccess& ast) const noexc
         }
 
         if (i == 0) {
-            type = symbol->getTypeProxy()->getType()->getLlvmType(m_gen->getContext());
+            type = symbol->getType()->getLlvmType(m_gen->getContext());
             addr = symbol->getLlvmValue();
         } else {
             idxs.push_back(builder.getInt32(symbol->getIndex()));
         }
 
-        if (symbol->getTypeProxy()->getType()->isPointer() && !last) {
+        if (symbol->getType()->isPointer() && !last) {
             createGEP();
-            type = llvm::cast<TypePointer>(symbol->getTypeProxy()->getType())->getBase()->getLlvmType(m_gen->getContext());
+            type = llvm::cast<TypePointer>(symbol->getType())->getBase()->getLlvmType(m_gen->getContext());
             addr = builder.CreateLoad(
-                symbol->getTypeProxy()->getType()->getLlvmType(m_gen->getContext()),
+                symbol->getType()->getLlvmType(m_gen->getContext()),
                 addr);
         }
     }

--- a/src/Gen/ValueHandler.cpp
+++ b/src/Gen/ValueHandler.cpp
@@ -7,8 +7,8 @@
 #include "Driver/Context.hpp"
 #include "Symbol/Symbol.hpp"
 #include "Type/Type.hpp"
-#include "Type/TypeUdt.hpp"
 #include "Type/TypeProxy.hpp"
+#include "Type/TypeUdt.hpp"
 using namespace lbc;
 using namespace Gen;
 

--- a/src/Gen/ValueHandler.cpp
+++ b/src/Gen/ValueHandler.cpp
@@ -8,37 +8,39 @@
 #include "Symbol/Symbol.hpp"
 #include "Type/Type.hpp"
 #include "Type/TypeUdt.hpp"
+#include "Type/TypeProxy.hpp"
 using namespace lbc;
 using namespace Gen;
 
 ValueHandler ValueHandler::createTemp(CodeGen& gen, AstExpr& expr, llvm::StringRef name) noexcept {
     auto* value = gen.visit(expr).load();
     auto* var = gen.getBuilder().CreateAlloca(
-        expr.type->getLlvmType(gen.getContext()),
+        expr.typeProxy->getType()->getLlvmType(gen.getContext()),
         nullptr,
         name);
     gen.getBuilder().CreateStore(value, var);
 
-    return createOpaqueValue(gen, expr.type, var, name);
+    return createOpaqueValue(gen, expr.typeProxy->getType(), var, name);
 }
 
 ValueHandler ValueHandler::createTempOrConstant(CodeGen& gen, AstExpr& expr, llvm::StringRef name) noexcept {
     auto* value = gen.visit(expr).load();
     if (llvm::isa<llvm::Constant>(value)) {
-        return { &gen, expr.type, value };
+        return { &gen, expr.typeProxy->getType(), value };
     }
 
     auto* var = gen.getBuilder().CreateAlloca(
-        expr.type->getLlvmType(gen.getContext()),
+        expr.typeProxy->getType()->getLlvmType(gen.getContext()),
         nullptr,
         name);
     gen.getBuilder().CreateStore(value, var);
 
-    return createOpaqueValue(gen, expr.type, var, name);
+    return createOpaqueValue(gen, expr.typeProxy->getType(), var, name);
 }
 
 ValueHandler ValueHandler::createOpaqueValue(CodeGen& gen, const TypeRoot* type, llvm::Value* value, llvm::StringRef name) noexcept {
-    auto* symbol = gen.getContext().create<Symbol>(name, type);
+    auto* typeProxy = gen.getContext().create<TypeProxy>(type);
+    auto* symbol = gen.getContext().create<Symbol>(name, typeProxy);
     symbol->setLlvmValue(value);
     return { &gen, symbol };
 }
@@ -47,19 +49,19 @@ ValueHandler::ValueHandler(CodeGen* gen, const TypeRoot* type, llvm::Value* valu
 : PointerUnion{ value }, m_gen{ gen }, m_type{ type } {}
 
 ValueHandler::ValueHandler(CodeGen* gen, Symbol* symbol) noexcept
-: PointerUnion{ symbol }, m_gen{ gen }, m_type{ symbol->type() } {}
+: PointerUnion{ symbol }, m_gen{ gen }, m_type{ symbol->getTypeProxy()->getType() } {}
 
 ValueHandler::ValueHandler(CodeGen* gen, AstIdentExpr& ast) noexcept
 : ValueHandler{ gen, ast.symbol } {}
 
 ValueHandler::ValueHandler(CodeGen* gen, AstMemberAccess& ast) noexcept
-: PointerUnion{ &ast }, m_gen{ gen }, m_type{ ast.type } {}
+: PointerUnion{ &ast }, m_gen{ gen }, m_type{ ast.typeProxy->getType() } {}
 
 ValueHandler::ValueHandler(CodeGen* gen, AstAddressOf& ast) noexcept
-: PointerUnion{ &ast }, m_gen{ gen }, m_type{ ast.type } {}
+: PointerUnion{ &ast }, m_gen{ gen }, m_type{ ast.typeProxy->getType() } {}
 
 ValueHandler::ValueHandler(CodeGen* gen, AstDereference& ast) noexcept
-: PointerUnion{ &ast }, m_gen{ gen }, m_type{ ast.type } {}
+: PointerUnion{ &ast }, m_gen{ gen }, m_type{ ast.typeProxy->getType() } {}
 
 llvm::Value* ValueHandler::getAddress() const noexcept {
     if (auto* value = dyn_cast<llvm::Value*>()) {
@@ -108,11 +110,11 @@ llvm::Type* ValueHandler::getLlvmType() const noexcept {
     }
 
     if (auto* symbol = dyn_cast<Symbol*>()) {
-        return symbol->type()->getLlvmType(m_gen->getContext());
+        return symbol->getTypeProxy()->getType()->getLlvmType(m_gen->getContext());
     }
 
     if (auto* ast = dyn_cast<AstExpr*>()) {
-        return ast->type->getLlvmType(m_gen->getContext());
+        return ast->typeProxy->getType()->getLlvmType(m_gen->getContext());
     }
 
     llvm_unreachable("Unknown type in getLlvmType");
@@ -145,17 +147,17 @@ llvm::Value* ValueHandler::getAggregageAddress(AstMemberAccess& ast) const noexc
         }
 
         if (i == 0) {
-            type = symbol->type()->getLlvmType(m_gen->getContext());
+            type = symbol->getTypeProxy()->getType()->getLlvmType(m_gen->getContext());
             addr = symbol->getLlvmValue();
         } else {
             idxs.push_back(builder.getInt32(symbol->getIndex()));
         }
 
-        if (symbol->type()->isPointer() && !last) {
+        if (symbol->getTypeProxy()->getType()->isPointer() && !last) {
             createGEP();
-            type = llvm::cast<TypePointer>(symbol->type())->getBase()->getLlvmType(m_gen->getContext());
+            type = llvm::cast<TypePointer>(symbol->getTypeProxy()->getType())->getBase()->getLlvmType(m_gen->getContext());
             addr = builder.CreateLoad(
-                symbol->type()->getLlvmType(m_gen->getContext()),
+                symbol->getTypeProxy()->getType()->getLlvmType(m_gen->getContext()),
                 addr);
         }
     }

--- a/src/Parser/ParseResult.hpp
+++ b/src/Parser/ParseResult.hpp
@@ -47,7 +47,8 @@ public:
     : m_value{ pointer, false } {}
 
     /// Downcast from derived type to base type
-    template<typename U, typename = std::enable_if_t<std::is_base_of_v<T, U>>>
+    template<typename U>
+    requires std::is_base_of_v<T, U>
     ParseResult(ParseResult<U> other) noexcept // NOLINT(hicpp-explicit-conversions)
     : m_value{ other.getPointer(), other.isError() } {}
 

--- a/src/Sem/Passes/ConstantFoldingPass.cpp
+++ b/src/Sem/Passes/ConstantFoldingPass.cpp
@@ -5,6 +5,7 @@
 #include "Driver/Context.hpp"
 #include "Sem/SemanticAnalyzer.hpp"
 #include "Type/Type.hpp"
+#include "Type/TypeProxy.hpp"
 using namespace lbc;
 using namespace Sem;
 
@@ -57,7 +58,7 @@ AstExpr* ConstantFoldingPass::visitUnaryExpr(const AstUnaryExpr& ast) {
 
     auto value = unary(ast.tokenKind, *literal);
     auto* repl = m_sem.getContext().create<AstLiteralExpr>(ast.range, value);
-    repl->type = ast.type;
+    repl->typeProxy = ast.typeProxy;
     return repl;
 }
 
@@ -134,7 +135,7 @@ AstExpr* ConstantFoldingPass::optimizeIifToCast(AstIfExpr& ast) {
             ast.expr,
             nullptr,
             true);
-        cast->type = ast.type;
+        cast->typeProxy = ast.typeProxy;
         return cast;
     }
 
@@ -149,7 +150,7 @@ AstExpr* ConstantFoldingPass::optimizeIifToCast(AstIfExpr& ast) {
             unary,
             nullptr,
             true);
-        cast->type = ast.type;
+        cast->typeProxy = ast.typeProxy;
         return cast;
     }
 
@@ -167,9 +168,9 @@ AstExpr* ConstantFoldingPass::visitCastExpr(const AstCastExpr& ast) {
         return nullptr;
     }
 
-    auto value = cast(ast.type, *literal);
+    auto value = cast(ast.typeProxy->getType(), *literal);
     auto* repl = m_sem.getContext().create<AstLiteralExpr>(ast.range, value);
-    repl->type = ast.type;
+    repl->typeProxy = ast.typeProxy;
     return repl;
 }
 
@@ -191,7 +192,7 @@ AstLiteralExpr::Value ConstantFoldingPass::cast(const TypeRoot* type, const AstL
         #undef INTEGRAL
     } else if (type->isBoolean()) {
         return castLiteral<bool, bool>(ast);
-    } else if (ast.type->isAnyPointer()) {
+    } else if (ast.typeProxy->getType()->isAnyPointer()) {
         return ast.value;
     }
     // clang-format on

--- a/src/Sem/Passes/ConstantFoldingPass.cpp
+++ b/src/Sem/Passes/ConstantFoldingPass.cpp
@@ -168,7 +168,7 @@ AstExpr* ConstantFoldingPass::visitCastExpr(const AstCastExpr& ast) {
         return nullptr;
     }
 
-    auto value = cast(ast.typeProxy->getType(), *literal);
+    auto value = cast(ast.getType(), *literal);
     auto* repl = m_sem.getContext().create<AstLiteralExpr>(ast.range, value);
     repl->typeProxy = ast.typeProxy;
     return repl;
@@ -192,7 +192,7 @@ AstLiteralExpr::Value ConstantFoldingPass::cast(const TypeRoot* type, const AstL
         #undef INTEGRAL
     } else if (type->isBoolean()) {
         return castLiteral<bool, bool>(ast);
-    } else if (ast.typeProxy->getType()->isAnyPointer()) {
+    } else if (ast.getType()->isAnyPointer()) {
         return ast.value;
     }
     // clang-format on

--- a/src/Sem/Passes/ForStmtPass.cpp
+++ b/src/Sem/Passes/ForStmtPass.cpp
@@ -39,13 +39,13 @@ void ForStmtPass::analyze(AstForStmt& ast) const noexcept {
         m_sem.expression(ast.step);
     }
 
-    const auto* type = ast.iterator->symbol->getTypeProxy()->getType();
+    const auto* type = ast.iterator->symbol->getType();
     if (!type->isNumeric()) {
         fatalError("NEXT iterator must be of numeric type");
     }
 
     // type TO type check
-    switch (type->compare(ast.limit->typeProxy->getType())) {
+    switch (type->compare(ast.limit->getType())) {
     case TypeComparison::Incompatible:
         fatalError("Incompatible types in FOR");
     case TypeComparison::Downcast:
@@ -57,7 +57,7 @@ void ForStmtPass::analyze(AstForStmt& ast) const noexcept {
         if (ast.iterator->typeExpr != nullptr) {
             m_sem.convert(ast.limit, type);
         } else {
-            m_sem.convert(ast.iterator->expr, ast.limit->typeProxy->getType());
+            m_sem.convert(ast.iterator->expr, ast.limit->getType());
             ast.iterator->symbol->setTypeProxy(ast.limit->typeProxy);
         }
         break;
@@ -65,7 +65,7 @@ void ForStmtPass::analyze(AstForStmt& ast) const noexcept {
 
     // type STEP type check
     if (ast.step != nullptr) {
-        switch (type->compare(ast.step->typeProxy->getType())) {
+        switch (type->compare(ast.step->getType())) {
         case TypeComparison::Incompatible:
             fatalError("Incompatible types in STEP");
         case TypeComparison::Downcast:
@@ -73,7 +73,7 @@ void ForStmtPass::analyze(AstForStmt& ast) const noexcept {
             const auto* dstTy = type;
             const auto* iterTy = llvm::dyn_cast<TypeIntegral>(type);
             if (iterTy != nullptr && !iterTy->isSigned()) {
-                if (const auto* stepIntTy = llvm::dyn_cast<TypeIntegral>(ast.step->typeProxy->getType())) {
+                if (const auto* stepIntTy = llvm::dyn_cast<TypeIntegral>(ast.step->getType())) {
                     if (stepIntTy->isSigned()) {
                         if (auto* literal = llvm::dyn_cast<AstLiteralExpr>(ast.step)) {
                             if (static_cast<int64_t>(std::get<uint64_t>(literal->value)) < 0) {
@@ -83,7 +83,7 @@ void ForStmtPass::analyze(AstForStmt& ast) const noexcept {
                             dstTy = iterTy->getSigned();
                         }
                     }
-                } else if (llvm::isa<TypeFloatingPoint>(ast.step->typeProxy->getType())) {
+                } else if (llvm::isa<TypeFloatingPoint>(ast.step->getType())) {
                     if (auto* literal = llvm::dyn_cast<AstLiteralExpr>(ast.step)) {
                         if (std::get<double>(literal->value) < 0.0) {
                             dstTy = iterTy->getSigned();
@@ -115,7 +115,7 @@ void ForStmtPass::analyze(AstForStmt& ast) const noexcept {
 void ForStmtPass::determineForDirection(AstForStmt& ast) const noexcept {
     auto* from = llvm::dyn_cast<AstLiteralExpr>(ast.iterator->expr);
     auto* to = llvm::dyn_cast<AstLiteralExpr>(ast.limit);
-    const auto* type = ast.iterator->symbol->getTypeProxy()->getType();
+    const auto* type = ast.iterator->symbol->getType();
     bool equal = false;
 
     if (from != nullptr && to != nullptr) {
@@ -163,7 +163,7 @@ void ForStmtPass::determineForDirection(AstForStmt& ast) const noexcept {
         return;
     }
 
-    if (step->typeProxy->getType()->isSignedIntegral()) {
+    if (step->getType()->isSignedIntegral()) {
         auto val = static_cast<int64_t>(std::get<uint64_t>(step->value));
         if (val < 0) {
             if (ast.direction == AstForStmt::Direction::Increment) {
@@ -187,14 +187,14 @@ void ForStmtPass::determineForDirection(AstForStmt& ast) const noexcept {
                 ast.direction = AstForStmt::Direction::Increment;
             }
         }
-    } else if (step->typeProxy->getType()->isUnsignedIntegral()) {
+    } else if (step->getType()->isUnsignedIntegral()) {
         auto val = std::get<uint64_t>(step->value);
         if (val == 0 || ast.direction == AstForStmt::Direction::Decrement) {
             ast.direction = AstForStmt::Direction::Skip;
         } else if (ast.direction == AstForStmt::Direction::Unknown) {
             ast.direction = AstForStmt::Direction::Increment;
         }
-    } else if (step->typeProxy->getType()->isFloatingPoint()) {
+    } else if (step->getType()->isFloatingPoint()) {
         auto val = std::get<double>(step->value);
         if (val < 0.0) {
             if (ast.direction == AstForStmt::Direction::Increment) {

--- a/src/Sem/Passes/ForStmtPass.cpp
+++ b/src/Sem/Passes/ForStmtPass.cpp
@@ -6,6 +6,7 @@
 #include "Driver/Context.hpp"
 #include "Sem/SemanticAnalyzer.hpp"
 #include "Type/Type.hpp"
+#include "Type/TypeProxy.hpp"
 using namespace lbc;
 using namespace Sem;
 
@@ -38,13 +39,13 @@ void ForStmtPass::analyze(AstForStmt& ast) const noexcept {
         m_sem.expression(ast.step);
     }
 
-    const auto* type = ast.iterator->symbol->type();
+    const auto* type = ast.iterator->symbol->getTypeProxy()->getType();
     if (!type->isNumeric()) {
         fatalError("NEXT iterator must be of numeric type");
     }
 
     // type TO type check
-    switch (type->compare(ast.limit->type)) {
+    switch (type->compare(ast.limit->typeProxy->getType())) {
     case TypeComparison::Incompatible:
         fatalError("Incompatible types in FOR");
     case TypeComparison::Downcast:
@@ -56,15 +57,15 @@ void ForStmtPass::analyze(AstForStmt& ast) const noexcept {
         if (ast.iterator->typeExpr != nullptr) {
             m_sem.convert(ast.limit, type);
         } else {
-            m_sem.convert(ast.iterator->expr, ast.limit->type);
-            ast.iterator->symbol->setType(ast.limit->type);
+            m_sem.convert(ast.iterator->expr, ast.limit->typeProxy->getType());
+            ast.iterator->symbol->setTypeProxy(ast.limit->typeProxy);
         }
         break;
     }
 
     // type STEP type check
     if (ast.step != nullptr) {
-        switch (type->compare(ast.step->type)) {
+        switch (type->compare(ast.step->typeProxy->getType())) {
         case TypeComparison::Incompatible:
             fatalError("Incompatible types in STEP");
         case TypeComparison::Downcast:
@@ -72,7 +73,7 @@ void ForStmtPass::analyze(AstForStmt& ast) const noexcept {
             const auto* dstTy = type;
             const auto* iterTy = llvm::dyn_cast<TypeIntegral>(type);
             if (iterTy != nullptr && !iterTy->isSigned()) {
-                if (const auto* stepIntTy = llvm::dyn_cast<TypeIntegral>(ast.step->type)) {
+                if (const auto* stepIntTy = llvm::dyn_cast<TypeIntegral>(ast.step->typeProxy->getType())) {
                     if (stepIntTy->isSigned()) {
                         if (auto* literal = llvm::dyn_cast<AstLiteralExpr>(ast.step)) {
                             if (static_cast<int64_t>(std::get<uint64_t>(literal->value)) < 0) {
@@ -82,7 +83,7 @@ void ForStmtPass::analyze(AstForStmt& ast) const noexcept {
                             dstTy = iterTy->getSigned();
                         }
                     }
-                } else if (llvm::isa<TypeFloatingPoint>(ast.step->type)) {
+                } else if (llvm::isa<TypeFloatingPoint>(ast.step->typeProxy->getType())) {
                     if (auto* literal = llvm::dyn_cast<AstLiteralExpr>(ast.step)) {
                         if (std::get<double>(literal->value) < 0.0) {
                             dstTy = iterTy->getSigned();
@@ -114,7 +115,7 @@ void ForStmtPass::analyze(AstForStmt& ast) const noexcept {
 void ForStmtPass::determineForDirection(AstForStmt& ast) const noexcept {
     auto* from = llvm::dyn_cast<AstLiteralExpr>(ast.iterator->expr);
     auto* to = llvm::dyn_cast<AstLiteralExpr>(ast.limit);
-    const auto* type = ast.iterator->symbol->type();
+    const auto* type = ast.iterator->symbol->getTypeProxy()->getType();
     bool equal = false;
 
     if (from != nullptr && to != nullptr) {
@@ -162,7 +163,7 @@ void ForStmtPass::determineForDirection(AstForStmt& ast) const noexcept {
         return;
     }
 
-    if (step->type->isSignedIntegral()) {
+    if (step->typeProxy->getType()->isSignedIntegral()) {
         auto val = static_cast<int64_t>(std::get<uint64_t>(step->value));
         if (val < 0) {
             if (ast.direction == AstForStmt::Direction::Increment) {
@@ -186,14 +187,14 @@ void ForStmtPass::determineForDirection(AstForStmt& ast) const noexcept {
                 ast.direction = AstForStmt::Direction::Increment;
             }
         }
-    } else if (step->type->isUnsignedIntegral()) {
+    } else if (step->typeProxy->getType()->isUnsignedIntegral()) {
         auto val = std::get<uint64_t>(step->value);
         if (val == 0 || ast.direction == AstForStmt::Direction::Decrement) {
             ast.direction = AstForStmt::Direction::Skip;
         } else if (ast.direction == AstForStmt::Direction::Unknown) {
             ast.direction = AstForStmt::Direction::Increment;
         }
-    } else if (step->type->isFloatingPoint()) {
+    } else if (step->typeProxy->getType()->isFloatingPoint()) {
         auto val = std::get<double>(step->value);
         if (val < 0.0) {
             if (ast.direction == AstForStmt::Direction::Increment) {

--- a/src/Sem/Passes/ForwardDeclPass.cpp
+++ b/src/Sem/Passes/ForwardDeclPass.cpp
@@ -2,29 +2,29 @@
 // Created by Albert on 26/02/2022.
 //
 #include "ForwardDeclPass.hpp"
-#include "Sem/SemanticAnalyzer.hpp"
 #include "Ast/Ast.hpp"
-#include "Type/TypeProxy.hpp"
 #include "Driver/Context.hpp"
+#include "Sem/SemanticAnalyzer.hpp"
+#include "Type/TypeProxy.hpp"
 using namespace lbc;
 using namespace Sem;
 
 namespace {
-    template<typename Callable>
-    inline void iterate(AstStmtList& ast, Callable callable) noexcept {
-        for (auto& stmt : ast.stmts) {
-            if (auto* decl = llvm::dyn_cast<AstDecl>(stmt)) {
-                callable(*decl);
-            }
-        }
-    }
-
-    template<typename Callable>
-    inline void iterate(AstDeclList& ast, Callable callable) noexcept {
-        for (auto& decl : ast.decls) {
+template<typename Callable>
+inline void iterate(AstStmtList& ast, Callable callable) noexcept {
+    for (auto& stmt : ast.stmts) {
+        if (auto* decl = llvm::dyn_cast<AstDecl>(stmt)) {
             callable(*decl);
         }
     }
+}
+
+template<typename Callable>
+inline void iterate(AstDeclList& ast, Callable callable) noexcept {
+    for (auto& decl : ast.decls) {
+        callable(*decl);
+    }
+}
 } // namespace
 
 void ForwardDeclPass::visit(AstModule& ast) noexcept {

--- a/src/Sem/Passes/ForwardDeclPass.cpp
+++ b/src/Sem/Passes/ForwardDeclPass.cpp
@@ -2,8 +2,47 @@
 // Created by Albert on 26/02/2022.
 //
 #include "ForwardDeclPass.hpp"
+#include "Sem/SemanticAnalyzer.hpp"
+#include "Ast/Ast.hpp"
+#include <functional>
+#include <llvm/ADT/TypeSwitch.h>
 using namespace lbc;
 using namespace Sem;
 
-void ForwardDeclPass::visit(AstModule&) const noexcept {
+namespace {
+    template<typename Callable>
+    inline void iterate(AstStmtList& ast, Callable callable) noexcept {
+        for (auto& stmt : ast.stmts) {
+            if (auto* decl = llvm::dyn_cast<AstDecl>(stmt)) {
+                callable(*decl);
+            }
+        }
+    }
+
+    template<typename Callable>
+    inline void iterate(AstDeclList& ast, Callable callable) noexcept {
+        for (auto& decl : ast.decls) {
+            callable(*decl);
+        }
+    }
+} // namespace
+
+void ForwardDeclPass::visit(AstModule& ast) noexcept {
+    iterate(*ast.stmtList, [&](auto& decl) { declare(decl); });
+}
+
+void ForwardDeclPass::declare(AstDecl& ast) noexcept {
+    if (not llvm::isa<AstFuncDecl, AstUdtDecl, AstTypeAlias>(ast)) {
+        return;
+    }
+
+    auto* symbol = m_sem.createNewSymbol(ast);
+    symbol->setDecl(&ast);
+    ast.symbol = symbol;
+
+    if (llvm::isa<AstFuncDecl>(ast)) {
+        m_types.push_back(symbol);
+    } else {
+        m_procs.push_back(symbol);
+    }
 }

--- a/src/Sem/Passes/ForwardDeclPass.cpp
+++ b/src/Sem/Passes/ForwardDeclPass.cpp
@@ -4,8 +4,8 @@
 #include "ForwardDeclPass.hpp"
 #include "Sem/SemanticAnalyzer.hpp"
 #include "Ast/Ast.hpp"
-#include <functional>
-#include <llvm/ADT/TypeSwitch.h>
+#include "Type/TypeProxy.hpp"
+#include "Driver/Context.hpp"
 using namespace lbc;
 using namespace Sem;
 
@@ -38,6 +38,7 @@ void ForwardDeclPass::declare(AstDecl& ast) noexcept {
 
     auto* symbol = m_sem.createNewSymbol(ast);
     symbol->setDecl(&ast);
+    symbol->setTypeProxy(m_sem.getContext().create<TypeProxy>());
     ast.symbol = symbol;
 
     if (llvm::isa<AstFuncDecl>(ast)) {

--- a/src/Sem/Passes/ForwardDeclPass.hpp
+++ b/src/Sem/Passes/ForwardDeclPass.hpp
@@ -5,7 +5,14 @@
 #include "Pass.hpp"
 
 namespace lbc {
+class Symbol;
 struct AstModule;
+struct AstStmtList;
+struct AstDecl;
+struct AstDeclList;
+struct AstFuncDecl;
+struct AstUdtDecl;
+struct AstTypeAlias;
 
 namespace Sem {
 
@@ -15,7 +22,12 @@ namespace Sem {
     class ForwardDeclPass final : public Pass {
     public:
         using Pass::Pass;
-        void visit(AstModule&) const noexcept;
+        void visit(AstModule&) noexcept;
+
+    private:
+        void declare(AstDecl& ast) noexcept;
+        std::vector<Symbol*> m_types{};
+        std::vector<Symbol*> m_procs{};
     };
 
 } // namespace Sem

--- a/src/Sem/Passes/FuncDeclarerPass.cpp
+++ b/src/Sem/Passes/FuncDeclarerPass.cpp
@@ -67,7 +67,7 @@ void FuncDeclarerPass::visitFuncDecl(AstFuncDecl& ast, bool external) {
         symbol->getFlags().external = external;
     }
 
-    const auto* type = m_sem.getTypePass().visit(ast);
+    auto* type = m_sem.getTypePass().visit(ast);
 
     // parameters
     ast.symbolTable = m_sem.getContext().create<SymbolTable>(symbolTale);
@@ -79,7 +79,7 @@ void FuncDeclarerPass::visitFuncDecl(AstFuncDecl& ast, bool external) {
         });
     }
 
-    symbol->setTypeProxy(type->getProxy());
+    symbol->setTypeProxy(type);
     ast.symbol = symbol;
 }
 

--- a/src/Sem/Passes/FuncDeclarerPass.cpp
+++ b/src/Sem/Passes/FuncDeclarerPass.cpp
@@ -7,6 +7,7 @@
 #include "Sem/SemanticAnalyzer.hpp"
 #include "Symbol/SymbolTable.hpp"
 #include "Type/Type.hpp"
+#include "Type/TypeProxy.hpp"
 #include "TypePass.hpp"
 using namespace lbc;
 using namespace Sem;
@@ -78,18 +79,18 @@ void FuncDeclarerPass::visitFuncDecl(AstFuncDecl& ast, bool external) {
         });
     }
 
-    symbol->setType(type);
+    symbol->setTypeProxy( m_sem.getContext().create<TypeProxy>(type));
     ast.symbol = symbol;
 }
 
 void FuncDeclarerPass::visit(AstFuncParamDecl& ast) {
-    const auto* type = ast.typeExpr->type;
+    const auto* type = ast.typeExpr->typeProxy->getType();
     if (type->isUDT()) {
         fatalError("Passing types by values is not implemented");
     }
 
     auto* symbol = createParamSymbol(ast);
-    symbol->setType(type);
+    symbol->setTypeProxy(ast.typeExpr->typeProxy);
     ast.symbol = symbol;
 }
 

--- a/src/Sem/Passes/FuncDeclarerPass.cpp
+++ b/src/Sem/Passes/FuncDeclarerPass.cpp
@@ -84,7 +84,7 @@ void FuncDeclarerPass::visitFuncDecl(AstFuncDecl& ast, bool external) {
 }
 
 void FuncDeclarerPass::visit(AstFuncParamDecl& ast) {
-    const auto* type = ast.typeExpr->typeProxy->getType();
+    const auto* type = ast.typeExpr->getType();
     if (type->isUDT()) {
         fatalError("Passing types by values is not implemented");
     }

--- a/src/Sem/Passes/FuncDeclarerPass.cpp
+++ b/src/Sem/Passes/FuncDeclarerPass.cpp
@@ -79,7 +79,7 @@ void FuncDeclarerPass::visitFuncDecl(AstFuncDecl& ast, bool external) {
         });
     }
 
-    symbol->setTypeProxy( m_sem.getContext().create<TypeProxy>(type));
+    symbol->setTypeProxy(type->getProxy());
     ast.symbol = symbol;
 }
 

--- a/src/Sem/Passes/TypeAliasDeclPass.cpp
+++ b/src/Sem/Passes/TypeAliasDeclPass.cpp
@@ -6,6 +6,8 @@
 #include "Sem/SemanticAnalyzer.hpp"
 #include "Type/Type.hpp"
 #include "TypePass.hpp"
+#include "Type/TypeProxy.hpp"
+#include "Driver/Context.hpp"
 using namespace lbc;
 using namespace Sem;
 
@@ -43,6 +45,6 @@ void TypeAliasDeclPass::visit(AstTypeAlias& ast) const noexcept {
         symbol->getFlags().type = true;
     }
 
-    symbol->setType(type);
+    symbol->setTypeProxy(ast.typeExpr->typeProxy);
     ast.symbol = symbol;
 }

--- a/src/Sem/Passes/TypeAliasDeclPass.cpp
+++ b/src/Sem/Passes/TypeAliasDeclPass.cpp
@@ -3,11 +3,11 @@
 //
 #include "TypeAliasDeclPass.hpp"
 #include "Ast/Ast.hpp"
+#include "Driver/Context.hpp"
 #include "Sem/SemanticAnalyzer.hpp"
 #include "Type/Type.hpp"
-#include "TypePass.hpp"
 #include "Type/TypeProxy.hpp"
-#include "Driver/Context.hpp"
+#include "TypePass.hpp"
 using namespace lbc;
 using namespace Sem;
 
@@ -24,7 +24,7 @@ void TypeAliasDeclPass::visit(AstModule& ast) const noexcept {
 }
 
 void TypeAliasDeclPass::visit(AstTypeAlias& ast) const noexcept {
-    const auto* type = m_sem.getTypePass().visit(*ast.typeExpr);
+    auto* proxy = m_sem.getTypePass().visit(*ast.typeExpr);
 
     auto* symbol = m_sem.createNewSymbol(ast);
     static constexpr auto getSymbol = Visitor{
@@ -45,6 +45,6 @@ void TypeAliasDeclPass::visit(AstTypeAlias& ast) const noexcept {
         symbol->getFlags().type = true;
     }
 
-    symbol->setTypeProxy(ast.typeExpr->typeProxy);
+    symbol->setTypeProxy(proxy);
     ast.symbol = symbol;
 }

--- a/src/Sem/Passes/TypePass.cpp
+++ b/src/Sem/Passes/TypePass.cpp
@@ -3,14 +3,13 @@
 //
 #include "TypePass.hpp"
 #include "Ast/Ast.hpp"
+#include "Driver/Context.hpp"
 #include "Sem/SemanticAnalyzer.hpp"
 #include "Symbol/Symbol.hpp"
 #include "Symbol/SymbolTable.hpp"
 #include "Type/Type.hpp"
+#include "Type/TypeProxy.hpp"
 #include "Type/TypeUdt.hpp"
-#include "Type/TypeProxy.hpp"
-#include "Driver/Context.hpp"
-#include "Type/TypeProxy.hpp"
 
 using namespace lbc;
 using namespace Sem;

--- a/src/Sem/Passes/TypePass.cpp
+++ b/src/Sem/Passes/TypePass.cpp
@@ -31,7 +31,7 @@ const TypeRoot* TypePass::visit(AstTypeExpr& ast) const noexcept {
     for (auto deref = 0; deref < ast.dereference; deref++) {
         type = TypePointer::get(m_sem.getContext(), type);
     }
-    ast.typeProxy = m_sem.getContext().create<TypeProxy>(type);
+    ast.typeProxy = type->getProxy();
     return ast.typeProxy->getType();
 }
 

--- a/src/Sem/Passes/TypePass.cpp
+++ b/src/Sem/Passes/TypePass.cpp
@@ -8,6 +8,8 @@
 #include "Symbol/SymbolTable.hpp"
 #include "Type/Type.hpp"
 #include "Type/TypeUdt.hpp"
+#include "Type/TypeProxy.hpp"
+#include "Driver/Context.hpp"
 
 using namespace lbc;
 using namespace Sem;
@@ -29,8 +31,8 @@ const TypeRoot* TypePass::visit(AstTypeExpr& ast) const noexcept {
     for (auto deref = 0; deref < ast.dereference; deref++) {
         type = TypePointer::get(m_sem.getContext(), type);
     }
-    ast.type = type;
-    return ast.type;
+    ast.typeProxy = m_sem.getContext().create<TypeProxy>(type);
+    return ast.typeProxy->getType();
 }
 
 const TypeRoot* TypePass::visit(AstIdentExpr& ast) const noexcept {
@@ -40,8 +42,8 @@ const TypeRoot* TypePass::visit(AstIdentExpr& ast) const noexcept {
     }
 
     if (sym->getFlags().type) {
-        ast.type = sym->type();
-        return ast.type;
+        ast.typeProxy = sym->getTypeProxy();
+        return ast.typeProxy->getType();
     }
 
     fatalError(""_t + sym->name() + " is not a type");

--- a/src/Sem/Passes/TypePass.cpp
+++ b/src/Sem/Passes/TypePass.cpp
@@ -71,5 +71,6 @@ TypeProxy* TypePass::visit(AstFuncDecl& ast) const noexcept {
     }
 
     // function
-    return TypeFunction::get(m_sem.getContext(), retType->getType(), std::move(paramTypes), ast.variadic)->getProxy();
+    const auto* type = TypeFunction::get(m_sem.getContext(), retType->getType(), std::move(paramTypes), ast.variadic);
+    return type->getProxy();
 }

--- a/src/Sem/Passes/TypePass.cpp
+++ b/src/Sem/Passes/TypePass.cpp
@@ -10,32 +10,33 @@
 #include "Type/TypeUdt.hpp"
 #include "Type/TypeProxy.hpp"
 #include "Driver/Context.hpp"
+#include "Type/TypeProxy.hpp"
 
 using namespace lbc;
 using namespace Sem;
 
-const TypeRoot* TypePass::visit(AstTypeExpr& ast) const noexcept {
+TypeProxy* TypePass::visit(AstTypeExpr& ast) const noexcept {
     const auto visitor = Visitor{
-        [](TokenKind kind) -> const TypeRoot* {
-            return TypeRoot::fromTokenKind(kind);
+        [](TokenKind kind) -> TypeProxy* {
+            return TypeRoot::fromTokenKind(kind)->getProxy();
         },
-        [&](AstIdentExpr* ident) -> const TypeRoot* {
+        [&](AstIdentExpr* ident) -> TypeProxy* {
             return visit(*ident);
         },
-        [&](AstFuncDecl* decl) -> const TypeRoot* {
+        [&](AstFuncDecl* decl) -> TypeProxy* {
             return visit(*decl);
         }
     };
-    const TypeRoot* type = std::visit(visitor, ast.expr);
+    auto* proxy = std::visit(visitor, ast.expr);
 
     for (auto deref = 0; deref < ast.dereference; deref++) {
-        type = TypePointer::get(m_sem.getContext(), type);
+        proxy = TypePointer::get(m_sem.getContext(), proxy->getType())->getProxy();
     }
-    ast.typeProxy = type->getProxy();
-    return ast.typeProxy->getType();
+    ast.typeProxy = proxy;
+    return proxy;
 }
 
-const TypeRoot* TypePass::visit(AstIdentExpr& ast) const noexcept {
+TypeProxy* TypePass::visit(AstIdentExpr& ast) const noexcept {
     auto* sym = m_sem.getSymbolTable()->find(ast.name);
     if (sym == nullptr) {
         fatalError("Undefined type "_t + ast.name);
@@ -43,33 +44,33 @@ const TypeRoot* TypePass::visit(AstIdentExpr& ast) const noexcept {
 
     if (sym->getFlags().type) {
         ast.typeProxy = sym->getTypeProxy();
-        return ast.typeProxy->getType();
+        return ast.typeProxy;
     }
 
     fatalError(""_t + sym->name() + " is not a type");
 }
 
-const TypeRoot* TypePass::visit(AstFuncDecl& ast) const noexcept {
+TypeProxy* TypePass::visit(AstFuncDecl& ast) const noexcept {
     // parameters
     std::vector<const TypeRoot*> paramTypes;
     if (ast.params != nullptr) {
         paramTypes.reserve(ast.params->params.size());
         for (auto& param : ast.params->params) {
-            paramTypes.emplace_back(visit(*param->typeExpr));
+            paramTypes.emplace_back(visit(*param->typeExpr)->getType());
         }
     }
 
     // return type
-    const TypeRoot* retType = nullptr;
+    const TypeProxy* retType = nullptr;
     if (ast.retTypeExpr != nullptr) {
         retType = visit(*ast.retTypeExpr);
-        if (retType->isUDT()) {
+        if (retType->getType()->isUDT()) {
             fatalError("Returning types by value is not implemented");
         }
     } else {
-        retType = TypeVoid::get();
+        retType = TypeVoid::get()->getProxy();
     }
 
     // function
-    return TypeFunction::get(m_sem.getContext(), retType, std::move(paramTypes), ast.variadic);
+    return TypeFunction::get(m_sem.getContext(), retType->getType(), std::move(paramTypes), ast.variadic)->getProxy();
 }

--- a/src/Sem/Passes/TypePass.hpp
+++ b/src/Sem/Passes/TypePass.hpp
@@ -15,8 +15,8 @@ namespace Sem {
     public:
         using Pass::Pass;
 
-        [[nodiscard]] const TypeRoot* visit(AstTypeExpr& ast) const noexcept;
-        [[nodiscard]] const TypeRoot* visit(AstFuncDecl& ast) const noexcept;
+        const TypeRoot* visit(AstTypeExpr& ast) const noexcept;
+        const TypeRoot* visit(AstFuncDecl& ast) const noexcept;
 
     private:
         [[nodiscard]] const TypeRoot* visit(AstIdentExpr& ast) const noexcept;

--- a/src/Sem/Passes/TypePass.hpp
+++ b/src/Sem/Passes/TypePass.hpp
@@ -5,7 +5,7 @@
 #include "Pass.hpp"
 
 namespace lbc {
-class TypeRoot;
+class TypeProxy;
 struct AstTypeExpr;
 struct AstIdentExpr;
 struct AstFuncDecl;
@@ -14,12 +14,11 @@ namespace Sem {
     class TypePass final : public Pass {
     public:
         using Pass::Pass;
-
-        const TypeRoot* visit(AstTypeExpr& ast) const noexcept;
-        const TypeRoot* visit(AstFuncDecl& ast) const noexcept;
+        [[nodiscard]] TypeProxy* visit(AstTypeExpr& ast) const noexcept;
+        [[nodiscard]] TypeProxy* visit(AstFuncDecl& ast) const noexcept;
 
     private:
-        [[nodiscard]] const TypeRoot* visit(AstIdentExpr& ast) const noexcept;
+        [[nodiscard]] TypeProxy* visit(AstIdentExpr& ast) const noexcept;
     };
 } // namespace Sem
 } // namespace lbc

--- a/src/Sem/Passes/UdtDeclPass.cpp
+++ b/src/Sem/Passes/UdtDeclPass.cpp
@@ -6,8 +6,8 @@
 #include "Driver/Context.hpp"
 #include "Sem/SemanticAnalyzer.hpp"
 #include "Type/Type.hpp"
-#include "Type/TypeUdt.hpp"
 #include "Type/TypeProxy.hpp"
+#include "Type/TypeUdt.hpp"
 using namespace lbc;
 using namespace Sem;
 

--- a/src/Sem/Passes/UdtDeclPass.cpp
+++ b/src/Sem/Passes/UdtDeclPass.cpp
@@ -7,6 +7,7 @@
 #include "Sem/SemanticAnalyzer.hpp"
 #include "Type/Type.hpp"
 #include "Type/TypeUdt.hpp"
+#include "Type/TypeProxy.hpp"
 using namespace lbc;
 using namespace Sem;
 
@@ -30,6 +31,7 @@ void UdtDeclPass::visit(AstStmtList& ast) noexcept {
 
 void UdtDeclPass::visit(AstUdtDecl& ast) noexcept {
     auto* symbol = m_sem.createNewSymbol(ast);
+    symbol->setTypeProxy(m_sem.getContext().create<TypeProxy>());
 
     bool packed = false;
     if (ast.attributes != nullptr) {

--- a/src/Sem/SemanticAnalyzer.cpp
+++ b/src/Sem/SemanticAnalyzer.cpp
@@ -73,6 +73,10 @@ void SemanticAnalyzer::visit(AstVarDecl& ast) {
         }
     }
 
+    if(type == nullptr) {
+        fatalError("no type for var declaration");
+    }
+
     // The Symbol
     auto* symbol = createNewSymbol(ast);
     symbol->getFlags().external = false;
@@ -129,7 +133,7 @@ void SemanticAnalyzer::visit(AstReturnStmt& ast) {
         retType = TypeIntegral::fromTokenKind(TokenKind::Integer);
         canOmitExpression = true;
     } else {
-        retType = llvm::cast<TypeFunction>(m_function->symbol->getTypeProxy()->getType())->getReturn();
+        retType = llvm::cast<TypeFunction>(m_function->symbol->getType())->getReturn();
     }
     auto isVoid = retType->isVoid();
     if (ast.expr == nullptr) {
@@ -145,11 +149,11 @@ void SemanticAnalyzer::visit(AstReturnStmt& ast) {
 
     expression(ast.expr);
 
-    if (ast.expr->typeProxy->getType() != retType) {
+    if (ast.expr->getType() != retType) {
         fatalError(
             "Return expression type mismatch."_t
             + " Expected (" + retType->asString() + ")"
-            + " got (" + ast.expr->typeProxy->getType()->asString() + ")");
+            + " got (" + ast.expr->getType()->asString() + ")");
     }
 }
 
@@ -171,9 +175,9 @@ void SemanticAnalyzer::visit(AstIfStmt& ast) {
         }
         if (block->expr != nullptr) {
             expression(block->expr);
-            if (!block->expr->typeProxy->getType()->isBoolean()) {
+            if (!block->expr->getType()->isBoolean()) {
                 fatalError("type '"_t
-                    + block->expr->typeProxy->getType()->asString()
+                    + block->expr->getType()->asString()
                     + "' cannot be used as boolean");
             }
         }
@@ -196,9 +200,9 @@ void SemanticAnalyzer::visit(AstDoLoopStmt& ast) {
 
     if (ast.expr != nullptr) {
         expression(ast.expr);
-        if (!ast.expr->typeProxy->getType()->isBoolean()) {
+        if (!ast.expr->getType()->isBoolean()) {
             fatalError("type '"_t
-                + ast.expr->typeProxy->getType()->asString()
+                + ast.expr->getType()->asString()
                 + "' cannot be used as boolean");
         }
     }
@@ -268,7 +272,7 @@ void SemanticAnalyzer::visit(AstAssignExpr& ast) {
     if (!ast.lhs->flags.assignable) {
         fatalError("Cannot assign");
     }
-    expression(ast.rhs, ast.lhs->typeProxy->getType());
+    expression(ast.rhs, ast.lhs->getType());
 }
 
 void SemanticAnalyzer::visit(AstIdentExpr& ast) {
@@ -277,12 +281,12 @@ void SemanticAnalyzer::visit(AstIdentExpr& ast) {
         fatalError("Unknown identifier "_t + ast.name);
     }
 
-    auto* type = symbol->getTypeProxy();
-    if (type == nullptr) {
+    auto* proxy = symbol->getTypeProxy();
+    if (proxy == nullptr) {
         fatalError("Identifier "_t + ast.name + " has unresolved type");
     }
 
-    ast.typeProxy = type;
+    ast.typeProxy = proxy;
     ast.symbol = symbol;
     ast.flags = symbol->getFlags();
 }
@@ -290,7 +294,7 @@ void SemanticAnalyzer::visit(AstIdentExpr& ast) {
 void SemanticAnalyzer::visit(AstCallExpr& ast) {
     visit(*ast.callable);
 
-    const auto* type = llvm::dyn_cast<TypeFunction>(ast.callable->typeProxy->getType());
+    const auto* type = llvm::dyn_cast<TypeFunction>(ast.callable->getType());
     if (type == nullptr) {
         fatalError("Trying to call a non callable");
     }
@@ -376,14 +380,14 @@ void SemanticAnalyzer::visit(AstDereference& ast) {
     // TODO dereference needs to return a reference to value, NOT value itself
 
     visit(*ast.expr);
-    if (const auto* type = llvm::dyn_cast<TypePointer>(ast.expr->typeProxy->getType())) {
+    if (const auto* type = llvm::dyn_cast<TypePointer>(ast.expr->getType())) {
         ast.typeProxy = type->getBase()->getProxy();
     } else {
         fatalError("dereferencing a non pointer");
     }
 
     ast.flags = ast.expr->flags;
-    if (!ast.typeProxy->getType()->isPointer()) {
+    if (!ast.getType()->isPointer()) {
         ast.flags.dereferencable = false;
     }
 }
@@ -397,7 +401,7 @@ void SemanticAnalyzer::visit(AstAddressOf& ast) {
     if (!ast.expr->flags.addressable) {
         fatalError("Cannot take address");
     }
-    ast.typeProxy = TypePointer::get(m_context, ast.expr->typeProxy->getType())->getProxy();
+    ast.typeProxy = TypePointer::get(m_context, ast.expr->getType())->getProxy();
     ast.flags = ast.expr->flags;
     ast.flags.dereferencable = true;
 }
@@ -540,7 +544,7 @@ void SemanticAnalyzer::visit(AstCastExpr& ast) {
     ast.typeProxy = m_typePass.visit(*ast.typeExpr);
     expression(ast.expr);
 
-    if (ast.expr->typeProxy->getType()->compare(ast.typeProxy->getType()) == TypeComparison::Incompatible) {
+    if (ast.expr->getType()->compare(ast.getType()) == TypeComparison::Incompatible) {
         fatalError("Incompatible cast");
     }
 
@@ -553,18 +557,18 @@ void SemanticAnalyzer::convert(AstExpr*& ast, const TypeRoot* type) {
 }
 
 void SemanticAnalyzer::coerce(AstExpr*& ast, const TypeRoot* type) {
-    if (ast->typeProxy->getType() == type) {
+    if (ast->getType() == type) {
         return;
     }
     const auto* src = type;
-    const auto* dst = ast->typeProxy->getType();
+    const auto* dst = ast->getType();
 
     switch (src->compare(dst)) {
     case TypeComparison::Incompatible:
         fatalError(
             "Type mismatch."_t
             + " Expected '" + type->asString() + "'"
-            + " got '" + ast->typeProxy->getType()->asString() + "'");
+            + " got '" + ast->getType()->asString() + "'");
     case TypeComparison::Downcast:
     case TypeComparison::Upcast:
         return cast(ast, type);

--- a/src/Sem/SemanticAnalyzer.cpp
+++ b/src/Sem/SemanticAnalyzer.cpp
@@ -62,8 +62,7 @@ void SemanticAnalyzer::visit(AstVarDecl& ast) {
     // m_type expr?
     TypeProxy* type = nullptr;
     if (ast.typeExpr != nullptr) {
-        m_typePass.visit(*ast.typeExpr);
-        type = ast.typeExpr->typeProxy;
+        type = m_typePass.visit(*ast.typeExpr);
     }
 
     // expression?
@@ -538,8 +537,7 @@ bool SemanticAnalyzer::canPerformBinary(TokenKind op, const TypeRoot* left, cons
 //------------------------------------------------------------------
 
 void SemanticAnalyzer::visit(AstCastExpr& ast) {
-    m_typePass.visit(*ast.typeExpr);
-    ast.typeProxy = ast.typeExpr->typeProxy;
+    ast.typeProxy = m_typePass.visit(*ast.typeExpr);
     expression(ast.expr);
 
     if (ast.expr->typeProxy->getType()->compare(ast.typeProxy->getType()) == TypeComparison::Incompatible) {

--- a/src/Sem/SemanticAnalyzer.cpp
+++ b/src/Sem/SemanticAnalyzer.cpp
@@ -315,7 +315,7 @@ void SemanticAnalyzer::visit(AstCallExpr& ast) {
         }
     }
 
-    ast.typeProxy = m_context.create<TypeProxy>(type->getReturn());
+    ast.typeProxy = type->getReturn()->getProxy();
 }
 
 void SemanticAnalyzer::visit(AstLiteralExpr& ast) {
@@ -340,7 +340,7 @@ void SemanticAnalyzer::visit(AstLiteralExpr& ast) {
         }
     };
     auto typeKind = std::visit(visitor, ast.value);
-    ast.typeProxy = m_context.create<TypeProxy>(TypeRoot::fromTokenKind(typeKind));
+    ast.typeProxy = TypeRoot::fromTokenKind(typeKind)->getProxy();
 }
 
 //------------------------------------------------------------------
@@ -378,7 +378,7 @@ void SemanticAnalyzer::visit(AstDereference& ast) {
 
     visit(*ast.expr);
     if (const auto* type = llvm::dyn_cast<TypePointer>(ast.expr->typeProxy->getType())) {
-        ast.typeProxy = m_context.create<TypeProxy>(type->getBase());
+        ast.typeProxy = type->getBase()->getProxy();
     } else {
         fatalError("dereferencing a non pointer");
     }
@@ -398,7 +398,7 @@ void SemanticAnalyzer::visit(AstAddressOf& ast) {
     if (!ast.expr->flags.addressable) {
         fatalError("Cannot take address");
     }
-    ast.typeProxy = m_context.create<TypeProxy>(TypePointer::get(m_context, ast.expr->typeProxy->getType()));
+    ast.typeProxy = TypePointer::get(m_context, ast.expr->typeProxy->getType())->getProxy();
     ast.flags = ast.expr->flags;
     ast.flags.dereferencable = true;
 }
@@ -468,7 +468,7 @@ void SemanticAnalyzer::arithmetic(AstBinaryExpr& ast) {
     const auto convert = [&](AstExpr*& expr, const TypeRoot* ty) {
         cast(expr, ty);
         m_constantFolder.fold(expr);
-        ast.typeProxy = m_context.create<TypeProxy>(ty);
+        ast.typeProxy = ty->getProxy();
     };
 
     switch (left->getType()->compare(right->getType())) {
@@ -505,7 +505,7 @@ void SemanticAnalyzer::comparison(AstBinaryExpr& ast) {
     const auto convert = [&](AstExpr*& expr, const TypeRoot* ty) {
         cast(expr, ty);
         m_constantFolder.fold(expr);
-        ast.typeProxy = m_context.create<TypeProxy>(TypeBoolean::get());
+        ast.typeProxy = TypeBoolean::get()->getProxy();
     };
 
     switch (left->getType()->compare(right->getType())) {
@@ -514,7 +514,7 @@ void SemanticAnalyzer::comparison(AstBinaryExpr& ast) {
     case TypeComparison::Downcast:
         return convert(ast.rhs, left->getType());
     case TypeComparison::Equal:
-        ast.typeProxy = m_context.create<TypeProxy>(TypeBoolean::get());
+        ast.typeProxy = TypeBoolean::get()->getProxy();
         return;
     case TypeComparison::Upcast:
         return convert(ast.lhs, right->getType());
@@ -582,7 +582,7 @@ void SemanticAnalyzer::cast(AstExpr*& ast, const TypeRoot* type) {
         ast,
         nullptr,
         true);
-    cast->typeProxy = m_context.create<TypeProxy>(type);
+    cast->typeProxy = type->getProxy();
     cast->flags = category;
     ast = cast; // NOLINT
 }
@@ -599,7 +599,7 @@ void SemanticAnalyzer::visit(AstIfExpr& ast) {
     const auto convert = [&](AstExpr*& expr, const TypeRoot* ty) {
         cast(expr, ty);
         m_constantFolder.fold(expr);
-        ast.typeProxy = m_context.create<TypeProxy>(ty);
+        ast.typeProxy = ty->getProxy();
     };
 
     auto* left = ast.trueExpr->typeProxy;

--- a/src/Sem/SemanticAnalyzer.cpp
+++ b/src/Sem/SemanticAnalyzer.cpp
@@ -9,10 +9,12 @@
 #include "Passes/FuncDeclarerPass.hpp"
 #include "Passes/TypeAliasDeclPass.hpp"
 #include "Passes/UdtDeclPass.hpp"
+#include "Passes/ForwardDeclPass.hpp"
 #include "Symbol/Symbol.hpp"
 #include "Symbol/SymbolTable.hpp"
 #include "Type/Type.hpp"
 #include "Type/TypeUdt.hpp"
+#include "Type/TypeProxy.hpp"
 
 using namespace lbc;
 
@@ -29,6 +31,7 @@ void SemanticAnalyzer::visit(AstModule& ast) {
     Sem::UdtDeclPass(*this).visit(ast);
     Sem::TypeAliasDeclPass(*this).visit(ast);
     Sem::FuncDeclarerPass(*this).visit(ast);
+//    Sem::ForwardDeclPass(*this).visit(ast);
 
     visit(*ast.stmtList);
 }
@@ -57,17 +60,17 @@ void SemanticAnalyzer::visit(AstExprStmt& ast) {
 
 void SemanticAnalyzer::visit(AstVarDecl& ast) {
     // m_type expr?
-    const TypeRoot* type = nullptr;
+    TypeProxy* type = nullptr;
     if (ast.typeExpr != nullptr) {
-        type = m_typePass.visit(*ast.typeExpr);
+        m_typePass.visit(*ast.typeExpr);
+        type = ast.typeExpr->typeProxy;
     }
 
     // expression?
     if (ast.expr != nullptr) {
-        expression(ast.expr, type);
-
+        expression(ast.expr, type == nullptr ? nullptr: type->getType());
         if (type == nullptr) {
-            type = ast.expr->type;
+            type = ast.expr->typeProxy;
         }
     }
 
@@ -76,12 +79,12 @@ void SemanticAnalyzer::visit(AstVarDecl& ast) {
     symbol->getFlags().external = false;
 
     // create function symbol
-    symbol->setType(type);
+    symbol->setTypeProxy(type);
     ast.symbol = symbol;
     auto flags = ast.symbol->getFlags();
     flags.addressable = true;
     flags.assignable = true;
-    if (type->isPointer()) {
+    if (type->getType()->isPointer()) {
         flags.dereferencable = true;
     }
     ast.symbol->setFlags(flags);
@@ -127,7 +130,7 @@ void SemanticAnalyzer::visit(AstReturnStmt& ast) {
         retType = TypeIntegral::fromTokenKind(TokenKind::Integer);
         canOmitExpression = true;
     } else {
-        retType = llvm::cast<TypeFunction>(m_function->symbol->type())->getReturn();
+        retType = llvm::cast<TypeFunction>(m_function->symbol->getTypeProxy()->getType())->getReturn();
     }
     auto isVoid = retType->isVoid();
     if (ast.expr == nullptr) {
@@ -143,11 +146,11 @@ void SemanticAnalyzer::visit(AstReturnStmt& ast) {
 
     expression(ast.expr);
 
-    if (ast.expr->type != retType) {
+    if (ast.expr->typeProxy->getType() != retType) {
         fatalError(
             "Return expression type mismatch."_t
             + " Expected (" + retType->asString() + ")"
-            + " got (" + ast.expr->type->asString() + ")");
+            + " got (" + ast.expr->typeProxy->getType()->asString() + ")");
     }
 }
 
@@ -169,9 +172,9 @@ void SemanticAnalyzer::visit(AstIfStmt& ast) {
         }
         if (block->expr != nullptr) {
             expression(block->expr);
-            if (!block->expr->type->isBoolean()) {
+            if (!block->expr->typeProxy->getType()->isBoolean()) {
                 fatalError("type '"_t
-                    + block->expr->type->asString()
+                    + block->expr->typeProxy->getType()->asString()
                     + "' cannot be used as boolean");
             }
         }
@@ -194,9 +197,9 @@ void SemanticAnalyzer::visit(AstDoLoopStmt& ast) {
 
     if (ast.expr != nullptr) {
         expression(ast.expr);
-        if (!ast.expr->type->isBoolean()) {
+        if (!ast.expr->typeProxy->getType()->isBoolean()) {
             fatalError("type '"_t
-                + ast.expr->type->asString()
+                + ast.expr->typeProxy->getType()->asString()
                 + "' cannot be used as boolean");
         }
     }
@@ -266,7 +269,7 @@ void SemanticAnalyzer::visit(AstAssignExpr& ast) {
     if (!ast.lhs->flags.assignable) {
         fatalError("Cannot assign");
     }
-    expression(ast.rhs, ast.lhs->type);
+    expression(ast.rhs, ast.lhs->typeProxy->getType());
 }
 
 void SemanticAnalyzer::visit(AstIdentExpr& ast) {
@@ -275,12 +278,12 @@ void SemanticAnalyzer::visit(AstIdentExpr& ast) {
         fatalError("Unknown identifier "_t + ast.name);
     }
 
-    const auto* type = symbol->type();
+    auto* type = symbol->getTypeProxy();
     if (type == nullptr) {
         fatalError("Identifier "_t + ast.name + " has unresolved type");
     }
 
-    ast.type = type;
+    ast.typeProxy = type;
     ast.symbol = symbol;
     ast.flags = symbol->getFlags();
 }
@@ -288,7 +291,7 @@ void SemanticAnalyzer::visit(AstIdentExpr& ast) {
 void SemanticAnalyzer::visit(AstCallExpr& ast) {
     visit(*ast.callable);
 
-    const auto* type = llvm::dyn_cast<TypeFunction>(ast.callable->type);
+    const auto* type = llvm::dyn_cast<TypeFunction>(ast.callable->typeProxy->getType());
     if (type == nullptr) {
         fatalError("Trying to call a non callable");
     }
@@ -312,7 +315,7 @@ void SemanticAnalyzer::visit(AstCallExpr& ast) {
         }
     }
 
-    ast.type = type->getReturn();
+    ast.typeProxy = m_context.create<TypeProxy>(type->getReturn());
 }
 
 void SemanticAnalyzer::visit(AstLiteralExpr& ast) {
@@ -337,7 +340,7 @@ void SemanticAnalyzer::visit(AstLiteralExpr& ast) {
         }
     };
     auto typeKind = std::visit(visitor, ast.value);
-    ast.type = TypeRoot::fromTokenKind(typeKind);
+    ast.typeProxy = m_context.create<TypeProxy>(TypeRoot::fromTokenKind(typeKind));
 }
 
 //------------------------------------------------------------------
@@ -346,18 +349,18 @@ void SemanticAnalyzer::visit(AstLiteralExpr& ast) {
 
 void SemanticAnalyzer::visit(AstUnaryExpr& ast) {
     expression(ast.expr);
-    const auto* type = ast.expr->type;
+    auto* type = ast.expr->typeProxy;
 
     switch (ast.tokenKind) {
     case TokenKind::LogicalNot:
-        if (type->isBoolean()) {
-            ast.type = type;
+        if (type->getType()->isBoolean()) {
+            ast.typeProxy = type;
             return;
         }
         fatalError("Applying unary NOT to non bool type");
     case TokenKind::Negate:
-        if (type->isNumeric()) {
-            ast.type = type;
+        if (type->getType()->isNumeric()) {
+            ast.typeProxy = type;
             return;
         }
         fatalError("Applying unary negate to non-numeric type");
@@ -374,14 +377,14 @@ void SemanticAnalyzer::visit(AstDereference& ast) {
     // TODO dereference needs to return a reference to value, NOT value itself
 
     visit(*ast.expr);
-    if (const auto* type = llvm::dyn_cast<TypePointer>(ast.expr->type)) {
-        ast.type = type->getBase();
+    if (const auto* type = llvm::dyn_cast<TypePointer>(ast.expr->typeProxy->getType())) {
+        ast.typeProxy = m_context.create<TypeProxy>(type->getBase());
     } else {
         fatalError("dereferencing a non pointer");
     }
 
     ast.flags = ast.expr->flags;
-    if (!ast.type->isPointer()) {
+    if (!ast.typeProxy->getType()->isPointer()) {
         ast.flags.dereferencable = false;
     }
 }
@@ -395,7 +398,7 @@ void SemanticAnalyzer::visit(AstAddressOf& ast) {
     if (!ast.expr->flags.addressable) {
         fatalError("Cannot take address");
     }
-    ast.type = TypePointer::get(m_context, ast.expr->type);
+    ast.typeProxy = m_context.create<TypeProxy>(TypePointer::get(m_context, ast.expr->typeProxy->getType()));
     ast.flags = ast.expr->flags;
     ast.flags.dereferencable = true;
 }
@@ -410,16 +413,16 @@ void SemanticAnalyzer::visit(AstMemberAccess& ast) {
     for (size_t i = 0; i < ast.exprs.size(); i++) {
         auto* expr = ast.exprs[i];
         visit(*expr);
-        const auto* type = expr->type;
+        auto* type = expr->typeProxy;
 
         if (i == (ast.exprs.size() - 1)) {
-            ast.type = type;
+            ast.typeProxy = type;
             ast.flags = expr->flags;
         } else {
             const TypeUDT* udt = nullptr;
-            if (type->isUDT()) {
-                udt = static_cast<const TypeUDT*>(type);
-            } else if (const auto* ptr = llvm::dyn_cast<TypePointer>(type)) {
+            if (type->getType()->isUDT()) {
+                udt = static_cast<const TypeUDT*>(type->getType());
+            } else if (const auto* ptr = llvm::dyn_cast<TypePointer>(type->getType())) {
                 if (ptr->getBase()->isUDT()) {
                     udt = static_cast<const TypeUDT*>(ptr->getBase());
                 }
@@ -455,66 +458,66 @@ void SemanticAnalyzer::visit(AstBinaryExpr& ast) {
 }
 
 void SemanticAnalyzer::arithmetic(AstBinaryExpr& ast) {
-    const auto* left = ast.lhs->type;
-    const auto* right = ast.rhs->type;
+    auto* left = ast.lhs->typeProxy;
+    auto* right = ast.rhs->typeProxy;
 
-    if (!left->isNumeric() || !right->isNumeric()) {
+    if (!left->getType()->isNumeric() || !right->getType()->isNumeric()) {
         fatalError("Applying artithmetic operation to non numeric type");
     }
 
     const auto convert = [&](AstExpr*& expr, const TypeRoot* ty) {
         cast(expr, ty);
         m_constantFolder.fold(expr);
-        ast.type = ty;
+        ast.typeProxy = m_context.create<TypeProxy>(ty);
     };
 
-    switch (left->compare(right)) {
+    switch (left->getType()->compare(right->getType())) {
     case TypeComparison::Incompatible:
         fatalError("Operator on incompatible types");
     case TypeComparison::Downcast:
-        return convert(ast.rhs, left);
+        return convert(ast.rhs, left->getType());
     case TypeComparison::Equal:
-        ast.type = left;
+        ast.typeProxy = left;
         return;
     case TypeComparison::Upcast:
-        return convert(ast.lhs, right);
+        return convert(ast.lhs, right->getType());
     }
 }
 
 void SemanticAnalyzer::logical(AstBinaryExpr& ast) {
-    const auto* left = ast.lhs->type;
-    const auto* right = ast.rhs->type;
+    auto* left = ast.lhs->typeProxy;
+    auto* right = ast.rhs->typeProxy;
 
-    if (!left->isBoolean() || !right->isBoolean()) {
+    if (!left->getType()->isBoolean() || !right->getType()->isBoolean()) {
         fatalError("Applying logical operator to non boolean type");
     }
-    ast.type = left;
+    ast.typeProxy = left;
 }
 
 void SemanticAnalyzer::comparison(AstBinaryExpr& ast) {
-    const auto* left = ast.lhs->type;
-    const auto* right = ast.rhs->type;
+    auto* left = ast.lhs->typeProxy;
+    auto* right = ast.rhs->typeProxy;
 
-    if (!canPerformBinary(ast.tokenKind, left, right)) {
+    if (!canPerformBinary(ast.tokenKind, left->getType(), right->getType())) {
         fatalError("Cannot apply operationg to types");
     }
 
     const auto convert = [&](AstExpr*& expr, const TypeRoot* ty) {
         cast(expr, ty);
         m_constantFolder.fold(expr);
-        ast.type = TypeBoolean::get();
+        ast.typeProxy = m_context.create<TypeProxy>(TypeBoolean::get());
     };
 
-    switch (left->compare(right)) {
+    switch (left->getType()->compare(right->getType())) {
     case TypeComparison::Incompatible:
         fatalError("Operator on incompatible types");
     case TypeComparison::Downcast:
-        return convert(ast.rhs, left);
+        return convert(ast.rhs, left->getType());
     case TypeComparison::Equal:
-        ast.type = TypeBoolean::get();
+        ast.typeProxy = m_context.create<TypeProxy>(TypeBoolean::get());
         return;
     case TypeComparison::Upcast:
-        return convert(ast.lhs, right);
+        return convert(ast.lhs, right->getType());
     }
 }
 
@@ -535,10 +538,11 @@ bool SemanticAnalyzer::canPerformBinary(TokenKind op, const TypeRoot* left, cons
 //------------------------------------------------------------------
 
 void SemanticAnalyzer::visit(AstCastExpr& ast) {
-    ast.type = m_typePass.visit(*ast.typeExpr);
+    m_typePass.visit(*ast.typeExpr);
+    ast.typeProxy = ast.typeExpr->typeProxy;
     expression(ast.expr);
 
-    if (ast.expr->type->compare(ast.type) == TypeComparison::Incompatible) {
+    if (ast.expr->typeProxy->getType()->compare(ast.typeProxy->getType()) == TypeComparison::Incompatible) {
         fatalError("Incompatible cast");
     }
 
@@ -551,18 +555,18 @@ void SemanticAnalyzer::convert(AstExpr*& ast, const TypeRoot* type) {
 }
 
 void SemanticAnalyzer::coerce(AstExpr*& ast, const TypeRoot* type) {
-    if (ast->type == type) {
+    if (ast->typeProxy->getType() == type) {
         return;
     }
     const auto* src = type;
-    const auto* dst = ast->type;
+    const auto* dst = ast->typeProxy->getType();
 
     switch (src->compare(dst)) {
     case TypeComparison::Incompatible:
         fatalError(
             "Type mismatch."_t
             + " Expected '" + type->asString() + "'"
-            + " got '" + ast->type->asString() + "'");
+            + " got '" + ast->typeProxy->getType()->asString() + "'");
     case TypeComparison::Downcast:
     case TypeComparison::Upcast:
         return cast(ast, type);
@@ -578,7 +582,7 @@ void SemanticAnalyzer::cast(AstExpr*& ast, const TypeRoot* type) {
         ast,
         nullptr,
         true);
-    cast->type = type;
+    cast->typeProxy = m_context.create<TypeProxy>(type);
     cast->flags = category;
     ast = cast; // NOLINT
 }
@@ -595,21 +599,21 @@ void SemanticAnalyzer::visit(AstIfExpr& ast) {
     const auto convert = [&](AstExpr*& expr, const TypeRoot* ty) {
         cast(expr, ty);
         m_constantFolder.fold(expr);
-        ast.type = ty;
+        ast.typeProxy = m_context.create<TypeProxy>(ty);
     };
 
-    const auto* left = ast.trueExpr->type;
-    const auto* right = ast.falseExpr->type;
-    switch (left->compare(right)) {
+    auto* left = ast.trueExpr->typeProxy;
+    auto* right = ast.falseExpr->typeProxy;
+    switch (left->getType()->compare(right->getType())) {
     case TypeComparison::Incompatible:
         fatalError("Incompatible types");
     case TypeComparison::Downcast:
-        return convert(ast.falseExpr, left);
+        return convert(ast.falseExpr, left->getType());
     case TypeComparison::Equal:
-        ast.type = left;
+        ast.typeProxy = left;
         return;
     case TypeComparison::Upcast:
-        return convert(ast.trueExpr, right);
+        return convert(ast.trueExpr, right->getType());
     }
 }
 

--- a/src/Sem/SemanticAnalyzer.cpp
+++ b/src/Sem/SemanticAnalyzer.cpp
@@ -6,15 +6,15 @@
 #include "Driver/Context.hpp"
 #include "Lexer/Token.hpp"
 #include "Passes/ForStmtPass.hpp"
+#include "Passes/ForwardDeclPass.hpp"
 #include "Passes/FuncDeclarerPass.hpp"
 #include "Passes/TypeAliasDeclPass.hpp"
 #include "Passes/UdtDeclPass.hpp"
-#include "Passes/ForwardDeclPass.hpp"
 #include "Symbol/Symbol.hpp"
 #include "Symbol/SymbolTable.hpp"
 #include "Type/Type.hpp"
-#include "Type/TypeUdt.hpp"
 #include "Type/TypeProxy.hpp"
+#include "Type/TypeUdt.hpp"
 
 using namespace lbc;
 
@@ -31,7 +31,7 @@ void SemanticAnalyzer::visit(AstModule& ast) {
     Sem::UdtDeclPass(*this).visit(ast);
     Sem::TypeAliasDeclPass(*this).visit(ast);
     Sem::FuncDeclarerPass(*this).visit(ast);
-//    Sem::ForwardDeclPass(*this).visit(ast);
+    //    Sem::ForwardDeclPass(*this).visit(ast);
 
     visit(*ast.stmtList);
 }
@@ -67,13 +67,13 @@ void SemanticAnalyzer::visit(AstVarDecl& ast) {
 
     // expression?
     if (ast.expr != nullptr) {
-        expression(ast.expr, type == nullptr ? nullptr: type->getType());
+        expression(ast.expr, type == nullptr ? nullptr : type->getType());
         if (type == nullptr) {
             type = ast.expr->typeProxy;
         }
     }
 
-    if(type == nullptr) {
+    if (type == nullptr) {
         fatalError("no type for var declaration");
     }
 
@@ -250,8 +250,8 @@ void SemanticAnalyzer::visit(AstAttribute& /*ast*/) {
 // Types
 //----------------------------------------
 
-void SemanticAnalyzer::visit(AstTypeExpr& ast) {
-    // NOOP
+void SemanticAnalyzer::visit(AstTypeExpr& /*ast*/) {
+    llvm_unreachable("AstTypeExpr");
 }
 
 //----------------------------------------

--- a/src/Symbol/Symbol.cpp
+++ b/src/Symbol/Symbol.cpp
@@ -1,0 +1,11 @@
+//
+// Created by Albert on 27/02/2022.
+//
+#include "Symbol.hpp"
+#include "Type/TypeProxy.hpp"
+using namespace lbc;
+
+const TypeRoot* Symbol::getType() const noexcept {
+    if (m_typeProxy == nullptr) { return nullptr; }
+    return m_typeProxy->getType();
+}

--- a/src/Symbol/Symbol.cpp
+++ b/src/Symbol/Symbol.cpp
@@ -6,6 +6,8 @@
 using namespace lbc;
 
 const TypeRoot* Symbol::getType() const noexcept {
-    if (m_typeProxy == nullptr) { return nullptr; }
+    if (m_typeProxy == nullptr) {
+        return nullptr;
+    }
     return m_typeProxy->getType();
 }

--- a/src/Symbol/Symbol.hpp
+++ b/src/Symbol/Symbol.hpp
@@ -6,6 +6,7 @@
 
 namespace lbc {
 class TypeProxy;
+class TypeRoot;
 struct AstDecl;
 
 class Symbol final {
@@ -28,6 +29,8 @@ public:
 
     [[nodiscard]] TypeProxy* getTypeProxy() const noexcept { return m_typeProxy; }
     void setTypeProxy(TypeProxy* proxy) noexcept { m_typeProxy = proxy; }
+
+    [[nodiscard]] const TypeRoot* getType() const noexcept;
 
     [[nodiscard]] llvm::StringRef name() const noexcept { return m_name; }
 

--- a/src/Symbol/Symbol.hpp
+++ b/src/Symbol/Symbol.hpp
@@ -5,14 +5,15 @@
 #include "Ast/ValueFlags.hpp"
 
 namespace lbc {
-class TypeRoot;
+class TypeProxy;
+struct AstDecl;
 
 class Symbol final {
 public:
     NO_COPY_AND_MOVE(Symbol)
 
-    explicit Symbol(llvm::StringRef name, const TypeRoot* type = nullptr) noexcept
-    : m_name{ name }, m_type{ type }, m_alias{ "" } {}
+    explicit Symbol(llvm::StringRef name, TypeProxy* proxy = nullptr) noexcept
+    : m_name{ name }, m_typeProxy{ proxy }, m_alias{ "" } {}
 
     ~Symbol() noexcept = default;
 
@@ -25,8 +26,8 @@ public:
     [[nodiscard]] unsigned int getIndex() const noexcept { return m_index; }
     void setIndex(unsigned int index) noexcept { m_index = index; }
 
-    [[nodiscard]] const TypeRoot* type() const noexcept { return m_type; }
-    void setType(const TypeRoot* type) noexcept { m_type = type; }
+    [[nodiscard]] TypeProxy* getTypeProxy() const noexcept { return m_typeProxy; }
+    void setTypeProxy(TypeProxy* proxy) noexcept { m_typeProxy = proxy; }
 
     [[nodiscard]] llvm::StringRef name() const noexcept { return m_name; }
 
@@ -35,6 +36,9 @@ public:
 
     [[nodiscard]] llvm::StringRef alias() const noexcept { return m_alias; }
     void setAlias(llvm::StringRef alias) noexcept { m_alias = alias; }
+
+    [[nodiscard]] AstDecl* getDecl() const noexcept { return m_decl; }
+    void setDecl(AstDecl* decl) noexcept { m_decl = decl; }
 
     [[nodiscard]] llvm::StringRef identifier() const noexcept {
         if (m_alias.empty()) {
@@ -56,14 +60,15 @@ public:
 
     // Allow placement new
     void* operator new(size_t /*size*/, void* ptr) {
-        assert(ptr);
+        assert(ptr); // NOLINT
         return ptr;
     }
 
 private:
     const llvm::StringRef m_name;
-    const TypeRoot* m_type;
+    TypeProxy* m_typeProxy;
 
+    AstDecl* m_decl = nullptr;
     llvm::StringRef m_alias;
     llvm::Value* m_llvmValue = nullptr;
     Symbol* m_parent = nullptr;

--- a/src/Type/Type.hpp
+++ b/src/Type/Type.hpp
@@ -3,6 +3,7 @@
 //
 #pragma once
 #include "Type.def.hpp"
+#include "TypeProxy.hpp"
 
 namespace lbc {
 
@@ -49,6 +50,14 @@ public:
 
     [[nodiscard]] constexpr TypeFamily getKind() const noexcept { return m_kind; }
 
+    [[nodiscard]] TypeProxy* getProxy() const noexcept { return m_proxy; }
+    void setProxy(TypeProxy* proxy) const {
+        assert(proxy->getType() == nullptr &&  // NOLINT
+            "When setting type proxy, it should not override another type");
+        m_proxy = proxy;
+        m_proxy->setType(this);
+    }
+
     [[nodiscard]] llvm::Type* getLlvmType(Context& context) const noexcept {
         if (m_llvmType == nullptr) {
             m_llvmType = genLlvmType(context);
@@ -88,13 +97,16 @@ public:
     // clang-format on
 
 protected:
-    constexpr explicit TypeRoot(TypeFamily kind) noexcept : m_kind{ kind } {}
+    constexpr explicit TypeRoot(TypeFamily kind) noexcept
+    : m_kind{ kind }, m_proxyDefault{this, nullptr}, m_proxy{ &m_proxyDefault } {}
 
     [[nodiscard]] virtual llvm::Type* genLlvmType(Context& context) const = 0;
 
 private:
     mutable llvm::Type* m_llvmType = nullptr;
     const TypeFamily m_kind;
+    mutable TypeProxy m_proxyDefault;
+    mutable TypeProxy* m_proxy;
 };
 
 /**

--- a/src/Type/Type.hpp
+++ b/src/Type/Type.hpp
@@ -52,7 +52,7 @@ public:
 
     [[nodiscard]] TypeProxy* getProxy() const noexcept { return m_proxy; }
     void setProxy(TypeProxy* proxy) const {
-        assert(proxy->getType() == nullptr &&  // NOLINT
+        assert(proxy->getType() == nullptr && // NOLINT
             "When setting type proxy, it should not override another type");
         m_proxy = proxy;
         m_proxy->setType(this);
@@ -98,7 +98,7 @@ public:
 
 protected:
     constexpr explicit TypeRoot(TypeFamily kind) noexcept
-    : m_kind{ kind }, m_proxyDefault{this, nullptr}, m_proxy{ &m_proxyDefault } {}
+    : m_kind{ kind }, m_proxyDefault{ this, nullptr }, m_proxy{ &m_proxyDefault } {}
 
     [[nodiscard]] virtual llvm::Type* genLlvmType(Context& context) const = 0;
 

--- a/src/Type/TypeProxy.hpp
+++ b/src/Type/TypeProxy.hpp
@@ -14,11 +14,10 @@ struct AstDecl;
 class TypeProxy final {
 public:
     NO_COPY_AND_MOVE(TypeProxy)
-
-    TypeProxy() noexcept = default;
+    constexpr TypeProxy() noexcept = default;
     ~TypeProxy() noexcept = default;
 
-    explicit TypeProxy(const TypeRoot* type, AstDecl* decl = nullptr) noexcept
+    constexpr explicit TypeProxy(const TypeRoot* type, AstDecl* decl = nullptr) noexcept
         : m_decl{ decl }, m_type{ type } {}
 
     // no new / delete. Must be allocated in the context
@@ -32,13 +31,13 @@ public:
     }
 
     /// get Decl node (for UDT types)
-    [[nodiscard]] AstDecl* getDecl() const noexcept { return m_decl; }
+    [[nodiscard]] constexpr AstDecl* getDecl() const noexcept { return m_decl; }
 
     /// Get type
-    [[nodiscard]] const TypeRoot* getType() const noexcept { return m_type; }
+    [[nodiscard]] const constexpr TypeRoot* getType() const noexcept { return m_type; }
 
     /// Set Type
-    void setType(const TypeRoot* type) noexcept { m_type = type; }
+    constexpr void setType(const TypeRoot* type) noexcept { m_type = type; }
 
 private:
     AstDecl* m_decl = nullptr;

--- a/src/Type/TypeProxy.hpp
+++ b/src/Type/TypeProxy.hpp
@@ -18,7 +18,7 @@ public:
     ~TypeProxy() noexcept = default;
 
     constexpr explicit TypeProxy(const TypeRoot* type, AstDecl* decl = nullptr) noexcept
-        : m_decl{ decl }, m_type{ type } {}
+    : m_decl{ decl }, m_type{ type } {}
 
     // no new / delete. Must be allocated in the context
     void* operator new(size_t) = delete;

--- a/src/Type/TypeProxy.hpp
+++ b/src/Type/TypeProxy.hpp
@@ -1,0 +1,48 @@
+//
+// Created by Albert on 26/02/2022.
+//
+#pragma once
+
+namespace lbc {
+class TypeRoot;
+struct AstDecl;
+
+/**
+ * Proxy object used by AST nodes
+ * and symbols to late bind types
+ */
+class TypeProxy final {
+public:
+    NO_COPY_AND_MOVE(TypeProxy)
+
+    TypeProxy() noexcept = default;
+    ~TypeProxy() noexcept = default;
+
+    explicit TypeProxy(const TypeRoot* type, AstDecl* decl = nullptr) noexcept
+        : m_decl{ decl }, m_type{ type } {}
+
+    // no new / delete. Must be allocated in the context
+    void* operator new(size_t) = delete;
+    void operator delete(void*) = delete;
+
+    // Allow placement new
+    void* operator new(size_t /*size*/, void* ptr) {
+        assert(ptr); // NOLINT
+        return ptr;
+    }
+
+    /// get Decl node (for UDT types)
+    [[nodiscard]] AstDecl* getDecl() const noexcept { return m_decl; }
+
+    /// Get type
+    [[nodiscard]] const TypeRoot* getType() const noexcept { return m_type; }
+
+    /// Set Type
+    void setType(const TypeRoot* type) noexcept { m_type = type; }
+
+private:
+    AstDecl* m_decl = nullptr;
+    const TypeRoot* m_type = nullptr;
+};
+
+} // namespace lbc

--- a/src/Type/TypeUdt.cpp
+++ b/src/Type/TypeUdt.cpp
@@ -18,7 +18,7 @@ TypeUDT::TypeUDT(Symbol& symbol, SymbolTable& symbolTable, bool packed)
 }
 
 const TypeUDT* TypeUDT::get(Context& context, Symbol& symbol, SymbolTable& symbolTable, bool packed) {
-    if (const auto* type = symbol.getTypeProxy()->getType()) {
+    if (const auto* type = symbol.getType()) {
         if (const auto* udt = llvm::dyn_cast<TypeUDT>(type)) {
             return udt;
         }
@@ -36,7 +36,7 @@ llvm::Type* TypeUDT::genLlvmType(Context& context) const {
     llvm::SmallVector<llvm::Type*> elems;
     elems.reserve(m_symbolTable.size());
     for (auto* symbol : m_symbolTable.getSymbols()) {
-        auto* ty = symbol->getTypeProxy()->getType()->getLlvmType(context);
+        auto* ty = symbol->getType()->getLlvmType(context);
         elems.emplace_back(ty);
     }
     return llvm::StructType::create(

--- a/src/Type/TypeUdt.cpp
+++ b/src/Type/TypeUdt.cpp
@@ -5,6 +5,7 @@
 #include "Driver/Context.hpp"
 #include "Symbol/Symbol.hpp"
 #include "Symbol/SymbolTable.hpp"
+#include "Type/TypeProxy.hpp"
 using namespace lbc;
 
 TypeUDT::TypeUDT(Symbol& symbol, SymbolTable& symbolTable, bool packed)
@@ -12,12 +13,13 @@ TypeUDT::TypeUDT(Symbol& symbol, SymbolTable& symbolTable, bool packed)
   m_symbol{ symbol },
   m_symbolTable{ symbolTable },
   m_packed(packed) {
-    symbol.setType(this);
+    //symbol.setT(this);
+    symbol.getTypeProxy()->setType(this);
     symbol.getFlags().type = true;
 }
 
 const TypeUDT* TypeUDT::get(Context& context, Symbol& symbol, SymbolTable& symbolTable, bool packed) {
-    if (const auto* type = symbol.type()) {
+    if (const auto* type = symbol.getTypeProxy()->getType()) {
         if (const auto* udt = llvm::dyn_cast<TypeUDT>(type)) {
             return udt;
         }
@@ -35,7 +37,7 @@ llvm::Type* TypeUDT::genLlvmType(Context& context) const {
     llvm::SmallVector<llvm::Type*> elems;
     elems.reserve(m_symbolTable.size());
     for (auto* symbol : m_symbolTable.getSymbols()) {
-        auto* ty = symbol->type()->getLlvmType(context);
+        auto* ty = symbol->getTypeProxy()->getType()->getLlvmType(context);
         elems.emplace_back(ty);
     }
     return llvm::StructType::create(

--- a/src/Type/TypeUdt.cpp
+++ b/src/Type/TypeUdt.cpp
@@ -13,8 +13,7 @@ TypeUDT::TypeUDT(Symbol& symbol, SymbolTable& symbolTable, bool packed)
   m_symbol{ symbol },
   m_symbolTable{ symbolTable },
   m_packed(packed) {
-    //symbol.setT(this);
-    symbol.getTypeProxy()->setType(this);
+    setProxy(symbol.getTypeProxy());
     symbol.getFlags().type = true;
 }
 

--- a/src/Utils/Utils.hpp
+++ b/src/Utils/Utils.hpp
@@ -20,12 +20,14 @@ namespace lbc {
 // Enum Flags
 LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
 
-template<typename E, typename = std::enable_if_t<llvm::is_bitmask_enum<E>::value>>
+template<typename E>
+requires llvm::is_bitmask_enum<E>::value
 constexpr bool operator==(E lhs, std::underlying_type_t<E> rhs) noexcept {
     return lhs == static_cast<E>(rhs);
 }
 
-template<typename E, typename = std::enable_if_t<llvm::is_bitmask_enum<E>::value>>
+template<typename E>
+requires llvm::is_bitmask_enum<E>::value
 constexpr bool operator!=(E lhs, std::underlying_type_t<E> rhs) noexcept {
     return lhs != static_cast<E>(rhs);
 }

--- a/src/Utils/ValueRestorer.hpp
+++ b/src/Utils/ValueRestorer.hpp
@@ -4,7 +4,8 @@
 #pragma once
 namespace lbc {
 
-template<typename T, std::enable_if_t<std::is_trivially_copyable_v<T> && std::is_trivially_assignable_v<T&, T>, int> = 0>
+template<typename T>
+requires std::is_trivial_v<T>
 struct ValueRestorer final {
     NO_COPY_AND_MOVE(ValueRestorer)
     constexpr explicit ValueRestorer(T& value) noexcept : m_target{ value }, m_value{ value } {}

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <concepts>
 #include <filesystem>
 #include <functional>
 #include <memory>

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -24,7 +24,7 @@ using namespace std::literals::string_literals;
 // LLVM
 #if defined(_MSC_VER)
 #    pragma warning(push)
-#    pragma warning(disable : 4242 4244 4245 4267 4100 4458 4996 4324 4456 4624 4310 4127)
+#    pragma warning(disable : 4100 4127 4242 4244 4245 4267 4310 4324 4456 4458 4624)
 #endif
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringMap.h>


### PR DESCRIPTION
Implement type proxying.

This is so that ast nodes and symbol table uses proxy type objects instead of holding type directly. This way type information can be filled in a later stage, without the need to modify the ast tree nodes.